### PR TITLE
Reorganize and tweak content. Big, but time is short and I was unwise

### DIFF
--- a/docs/content_style_guide.md
+++ b/docs/content_style_guide.md
@@ -1,7 +1,7 @@
 ---
 id: content_style_guide
-title: Content and Plain Language Style Guide for Interviews
-sidebar_label: Content Style Guide
+title: Content and plain language style guide for interviews
+sidebar_label: Content style guide
 slug: /content_and_plain_language_style_guide
 ---
 

--- a/docs/doc_vars_overview.md
+++ b/docs/doc_vars_overview.md
@@ -5,12 +5,4 @@ sidebar_label: Overview
 slug: /overview
 ---
 
-:::note Resources
-- [Use the weaver to generate code](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1)
-- [See the GitHub repository](https://github.com/suffolkLITLab/docassemble-assemblylinewizard)
-
-**Samples**
-- [Sample PDF of the MA Family Law Generic Motion](./assets/generic_motion_family_law.pdf)
-- [Sample DOCX of the MA Family Law Generic Motion](./assets/generic_motion_family_law.docx)
-:::
-
+Under development

--- a/docs/doc_vars_reference.md
+++ b/docs/doc_vars_reference.md
@@ -1,35 +1,28 @@
 ---
 id: document_variables_reference
-title: Label Variables Quick Reference
-sidebar_label: Label Variables
+title: Label variables quick reference
+sidebar_label: Add labels and variables
 slug: /label_variables
 ---
 
-:::note Resources
-- [The Weaver code generator](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1)
-- [The ALWeaver GitHub repository](https://github.com/suffolkLITLab/docassemble-assemblylinewizard)
+To save time and effort later, use naming convension in your PDFs and DOCXs that the [AssemblyLine Weaver interview code generator](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1) will understand.
 
-**Samples**
-- [Sample PDF of the MA Family Law Generic Motion](./assets/generic_motion_family_law.pdf)
-- [Sample DOCX of the MA Family Law Generic Motion](./assets/generic_motion_family_law.docx)
-:::
+Note that these are just the words that the ALWeaver knows. They help you generate your starting code. They are just a subset of the variables in the AssemblyLine library. 
 
-Labels and variables you can use in your PDFs and DOCXs to make the most of the [AssemblyLine Weaver interview code generator](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1). It's more work now, but it should save you a bunch of work in the future.
-
-:::info
-This is a subset of the variables in the AssemblyLine library. These are just the words that the [ALWeaver](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1) knows. They help you generate your starting code.
-:::
+## Example documents
+- [A fully labeled PDF](./assets/generic_motion_family_law.pdf)
+- [The DOCX version of the same motion](./assets/generic_motion_family_law.docx)
 
 ## Prefixes: [Reserved words](#reserved-words) for objects
-<!-- TODO: put in overview Objects can be things like people or courts. -->
+<!-- TODO: put in overview Objects can be things like people or a court (trial_court). -->
 
-### People
+### People Prefixes
 Words that the [ALWeaver](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1) will automatically know are people.
 
 | Document output format | PDF label | Attachment | Interview order |
 |:-|:-|:-|:-|
 | **First M. Last** - name of the 1st user | user | user[0] | user[0] |
-| **First M. Last** - name of the 1st other_party | other_party | other_parties[0] | other_parties[0] |
+| **First M. Last** - name of the 1st other party | other_party | other_parties[0] | other_parties[0] |
 | **First M. Last** - name of the 1st plaintiff | plaintiff | plaintiff[0] | plaintiff[0] |
 | **First M. Last** - name of the 1st defendant | defendant | defendant[0] | defendant[0] |
 | **First M. Last** - name of the 1st petitioner | petitioner | petitioner[0] | petitioner[0] |
@@ -43,39 +36,46 @@ Words that the [ALWeaver](https://apps-dev.suffolklitlab.org/run/assemblylinewiz
 | **First M. Last** - name of the 1st debt_collector | debt_collector | debt_collector[0] | debt_collector[0] |
 | **First M. Last** - name of the 1st creditor | creditor | creditors[0]| creditors[0] |
 | **First M. Last** - name of the 1st child | child | children[0] | children[0] |
-| **First M. Last** - name of the 1st guardian_ad_litem | guardian_ad_litem | guardians_ad_litem[0] | guardians_ad_litem[0] |
+| **First M. Last** - name of the 1st guardian ad litem | guardian_ad_litem | guardians_ad_litem[0] | guardians_ad_litem[0] |
 | **First M. Last** - name of the 1st witnesses | witnesses | witnesses[0] | witnesses[0] |
 | **First M. Last** - name of the 1st decedent | decedent | decedents[0] | decedents[0] |
-| **First M. Last** - name of the 1st interested_party | interested_party | interested_parties[0] | interested_parties[0] |
+| **First M. Last** - name of the 1st interested party | interested_party | interested_parties[0] | interested_parties[0] |
 
 
-### Other objects
+### Other reserved words
 Other words the [ALWeaver](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1) will automatically know.
-
-:::caution
-The list of `courts` will be soon be replaced with one single `trial_court` object
-:::
 
 | Use case | Document output format | PDF label | Attachment | Interview order |
 |:-|:-|:-|:-|:-|
-| name of the 1st court | **Court Name** | court | courts[0] | courts[0] |
+| name of the court | **Court Name** | trial_court | trial_court | trial_court |
 | 1st docket number |**123456** | docket_number | docket_numbers[0] | docket_numbers[0] |
 | Date that the user signs the form | **February 4, 2021** | signature_date | signature_date | signature_date |
 
 ## Suffixes: [Reserved words](#reserved-words) for attributes
-These are attributes of people or things. One attribute of a `parent` might be their `birthdate`. In the table below, imagine we need information about someone's parent.
 
-<!-- TODO: check on mobile number -->
+<!-- TODO: Double check an example county name -->
+<!-- TODO: Come up with a second address for the mailing address? -->
 
-Reference material:
+### Field types
+<!-- These suffixes can be used to get the ALWeaver to automatically set the type of field that will be used and to create variables more effectively. It may affect the code that is generated. -->
 
-1. [Names](https://docassemble.org/docs/objects.html#Name)
-1. [Other things to do with individuals](https://docassemble.org/docs/objects.html#Individual)
+**`_date`**
+Something ending in `_date` will automatically show up in the weaver already set as a date field.
+**Example:** `hearing_date`
 
- <!-- TODO: Double check how county name would appear -->
- <!-- TODO: Come up with a second address for the mailing address? -->
+**`_yes` combined with `_no`**
+<!-- TODO: Move to overview doc if that's ever created -->
+For PDFs specifically. When two otherwise identical labels in a PDF end in `_yes` and `_no`, they will be combined into one variable in the interview order, and will appear in the online interview as a single checkbox.
+**Example:**
+`is_minor_yes` and `is_minor_no`
 
-### People
+| Document output format | PDF label | Attachment | Interview order |
+|:-|:-|:-|:-|
+| Minor 'Yes' checkbox is checked or blank | is_minor_yes | "is_minor_yes": ${ is_minor is True } | is_minor |
+| Minor 'No' checkbox is checked or blank | is_minor_no | "is_minor_no": ${ is_minor is not True } | is_minor |
+
+### People Suffixes
+<!-- These are attributes of people or things. One attribute of a `parent` might be their `birthdate`. In the table below, imagine we need information about someone's parent. -->
 
 | Document output format | PDF label | Attachment | Interview order |
 |:-|:-|:-|:-|
@@ -116,17 +116,31 @@ Reference material:
 | **Boston, MA 02108** | parent<strong>_mail_address_city_state_zip</strong> | parents[0]<strong>.mail_address.line_two()</strong> | parents[0]<strong>.mail_address.address</strong> |
 | An image of a signature | parent<strong>_signature</strong> | parents[0]<strong>.signature</strong> | parents[0]<strong>.signature</strong> |
 | **123-123-1234** - landline number of 1st parent | parent<strong>_phone_number</strong> | parents[0]<strong>.phone_number</strong> | parents[0]<strong>.phone_number</strong> |
+| **123-123-1234** - mobile number of 1st parent | parent<strong>_mobile_number</strong> | parents[0]<strong>.mobile_number</strong> | parents[0]<strong>.mobile_number</strong> |
 | **123-123-1234 (cell)** or **123-123-1234 (other)** or **123-123-1234 (cell) 123-123-1234 (other)** - one or more phone numbers of 1st parent | parent<strong>_phones</strong> | parents[0]<strong>.phone_numbers()</strong> | - |
 
-:::info
-`.phone_numbers()` is a method that AssemblyLine has added
+<!-- 
+:::info Custom AssemblyLine methods
+- `.phone_numbers()`
+- `.familiar()`
+- `.familiar_or()`
 :::
+-->
 
-### Courts
+<!-- TODO: Do the resources below belong elsewhere? -->
+<!-- TODO: This is stuff I've gotten questions about -->
+
+Docassemble resources:
+1. [Names](https://docassemble.org/docs/objects.html#Name)
+1. [Other things to do with individuals](https://docassemble.org/docs/objects.html#Individual)
+
+### Court
 | Document output format | PDF label | Attachment | Interview order |
 |:-|:-|:-|:-|
-| **Division name** - division of the 1st court | court<strong>_division</strong> | courts[0]<strong>.division</strong> | courts[0]<strong>.division</strong> |
-| **County name** - county of the 1st court | court<strong>_county</strong> | courts[0]<strong>.address.county</strong> | courts[0]<strong>.address.county</strong> |
+| **Court name** - name of the court | trial_court | trial_court | trial_court |
+| **County name** - county of the court | trial_court<strong>_county</strong> | trial_court<strong>.address.county</strong> | trial_court<strong>.address.address</strong> |
+| **Division name** - division of the court | trial_court<strong>_division</strong> | trial_court<strong>.division</strong> | trial_court<strong>.division</strong> |
+| **Department name** - deparment of the court | trial_court<strong>_deparment</strong> | trial_court<strong>.deparment</strong> | trial_court<strong>.deparment</strong> |
 
 
 ## More than one
@@ -137,10 +151,7 @@ Situations where you have any these:
 
 <!-- TODO: Add definition of 'reserved word' in overview and link to that in the tip -->
 
-:::tip
-1. You can do the below for any reserved word  on the page.
-1. You can combine these methods.
-:::
+You can do the below for any reserved word  on the page. You can also use these methods in combination.
 
 ### Multiple items of one category
 For example, when there are multiple children.
@@ -165,18 +176,12 @@ When docassemble reads PDFs, each field should have a **unique label**. That mea
 | **First M. Last** - 2nd appearance of name of 1st plaintiff | plaintiff<strong>__2</strong> | plaintiffs[0].gather() | plaintiffs[0].name |
 
 ### Print all the items in one spot
-List all the plaintiffs, all the courts, all the docket numbers, etc.
+List all the plaintiffs, all the docket numbers, etc. All [people words](#people_prefixes) can be used.
 
-:::info
-All [people words](#people) can be used
-:::
-
-<!-- TODO: Check on way that courts are 'gathered'? -->
 <!-- TODO: Check on way that docket numbers are 'gathered'? -->
 
 | Document output format | PDF label | Attachment | Interview order |
 |:-|:-|:-|:-|
-| **Court1 Name, Court2 Name** - names of all courts | courts | courts | courts.gather |
 | **123456, 654321** - list of all docket numbers | docket_numbers | docket_numbers | docket_numbers |
 | **123-123-1234 (cell)** or **123-123-1234 (other)** or **123-123-1234 (cell) 123-123-1234 (other)** - one or more phone numbers of 1st parent | parent<strong>_phones</strong> | parents[0]<strong>.phone_numbers()</strong> | - |
 | **First M. Last** of every user | users | users | users.gather() |
@@ -221,9 +226,7 @@ Some [reserved words](#reserved-words) that are just in DOCX files.
 | **Firstname1, Firstname2, or Firstname3** - the 1st names of all the children joined with 'or'. Works for a single child too. | children.familiar_or() | - |
 | **123-123-1234 (cell)** or **123-123-1234 (other)** or **123-123-1234 (cell) 123-123-1234 (other)** - one or more numbers of 1st parent | parents[0].phone_numbers() | - |
 
-:::info
-You can do more with `a_date.format()`. See [the docassemble DADateTime documentation](https://docassemble.org/docs/objects.html#DADateTime)
-:::
+For more about `.format()`, see [the docassemble DADateTime documentation](https://docassemble.org/docs/objects.html#DADateTime)
 
 ## Definitions
 

--- a/docs/doc_vars_reference.md
+++ b/docs/doc_vars_reference.md
@@ -5,7 +5,7 @@ sidebar_label: Add labels and variables
 slug: /label_variables
 ---
 
-To save time and effort later, use naming convension in your PDFs and DOCXs that the [AssemblyLine Weaver interview code generator](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1) will understand.
+To save time and effort later, use the naming conventions in your PDFs and DOCXs that the [AssemblyLine Weaver interview code generator](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1) will understand.
 
 Note that these are just the words that the ALWeaver knows. They help you generate your starting code. They are just a subset of the variables in the AssemblyLine library. 
 

--- a/docs/docs_style_guide.md
+++ b/docs/docs_style_guide.md
@@ -1,7 +1,7 @@
 ---
 id: docs_style_guide
-title: Documentation Style Guide
-sidebar_label: Docs Style Guide
+title: Documentation style suide
+sidebar_label: Docs style guide
 slug: /documentation_style_guide
 ---
 
@@ -9,7 +9,7 @@ slug: /documentation_style_guide
 
 **Link to someone else's documentation when you can.** If you want to give information that isn't specific to AssemblyLine, try to find documentation that is being maintained by someone else. If it's something about Trello, try to find the Trello documentation. For Github, try to find Github documentation. Same for docassemble. Their projects will do a much better job keeping up to date than you can. Only make new documentation when the existing documentation doesn't exist or is not enough.
 
-**Avoid resource links or index-type pages.** This site will have a search bar. Because of that, collecitons of links or pages that index other pages or content will end up appearing in the search findings even though they will not take the user to the meat of what they're looking for. [Agolia's docsearch](https://docsearch.algolia.com/) will power our searches. See [Agolia's passage on the topic](https://docsearch.algolia.com/docs/tips/#avoid-duplicates-by-promoting-unicity) and [the more extensive article they link to](https://www.algolia.com/blog/engineering/how-to-build-a-helpful-search-for-technical-documentation-the-laravel-example/#1-relevant-content-only) (search for 'Relevant content onlyl').
+**Avoid resource link or index-type pages.** This site will have a search bar. Because of that, collections of links or pages that index other pages or content will end up appearing in the search findings even though they will not take the user to the meat of what they're looking for. [Agolia's docsearch](https://docsearch.algolia.com/) will power our searches. See [Agolia's passage on the topic](https://docsearch.algolia.com/docs/tips/#avoid-duplicates-by-promoting-unicity) and [the more extensive article they link to](https://www.algolia.com/blog/engineering/how-to-build-a-helpful-search-for-technical-documentation-the-laravel-example/#1-relevant-content-only) (search for 'Relevant content onlyl').
 
 
 ## Markdown Syntax

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,11 +1,15 @@
 ---
 id: getting_started
-title: Getting Started
-sidebar_label: Getting Started
+title: Getting started
+sidebar_label: Getting started
 slug: /getting_started
 ---
 
-How do you develop and deploy effectively? This is what has worked for us. Adjust it when you need to. We'd love to hear about the changes you make!
+<!-- TODO: Add link to someplace to give feedback or some kind of forum. -->
+
+How do you develop and deploy court forms effectively? This is what has worked for us. Adjust it when you need to. We'd love to hear about the changes you make for your organization!
+
+Much of the documentation on this site is meant as reference material to support a developer as they work through the [step-by-step process](https://trello.com/c/uRD0ZIOc/1-form-name-type-of-law) this project has found useful.
 
 ## Summary
 1. Set up the system for your organization
@@ -27,7 +31,7 @@ How do you develop and deploy effectively? This is what has worked for us. Adjus
    1. Write tests for and test the interview
    1. Deploy the interview
 
-Below are some techniques and knowledge we have found useful for starting the development of a form.
+Below are some general techniques and knowledge we have found useful for starting the development of a form.
 
 ## Stick to an MVP
 **MVP:** Minimum viable product - first make something that works. 

--- a/docs/github.md
+++ b/docs/github.md
@@ -1,7 +1,7 @@
 ---
 id: github
-title: Sharing Code Through Github
-sidebar_label: Github
+title: Using Github with docassemble
+sidebar_label: Github tutorials
 slug: /github
 ---
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 id: intro
 title: The docassemble AssemblyLine Project
-sidebar_label: Intro
+sidebar_label: About
 slug: /
 ---
 

--- a/docs/name_formats.md
+++ b/docs/name_formats.md
@@ -8,7 +8,7 @@ slug: /naming
 In programming languages (and sometimes in computer files and names in general),
 there are a lot of different rules that could be used to name different things like files
 and variables. When working in a large team, choosing consistent conventions for naming these
-things makes reading and writing code easier. At the Assembly Line project, we've settled on
+things makes reading and writing code easier. At the AssemblyLine project, we've settled on
 several conventions:
 
 1. [`snake_case`](#snake_case)

--- a/docs/pdfs.md
+++ b/docs/pdfs.md
@@ -1,7 +1,7 @@
 ---
 id: pdfs
 title: Working with PDF files
-sidebar_label: Editing PDFs
+sidebar_label: Tools to edit PDFs
 slug: /pdfs
 ---
 

--- a/docs/weaver_code_anatomy.md
+++ b/docs/weaver_code_anatomy.md
@@ -1,16 +1,11 @@
 ---
 id: yaml_anatomy
-title: The Anatomy of an ALWeaver Generated YAML File
-sidebar_label: Anatomy of the YAML
+title: The parts of an ALWeaver generated YAML file
+sidebar_label: View the generated code
 slug: /generated_yaml
 ---
 
-:::note
-- [Use the weaver to generate code](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1)
-- [See the GitHub repository](https://github.com/suffolkLITLab/docassemble-assemblylinewizard)
-:::
-
-The code [ALWeaver](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1) generates is just a starting point. It uses the [labels and variables you added to your templates](doc_vars_reference.md) to make an interview that uses the AssemblyLine library.
+The code [ALWeaver](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1) generates is just a starting point. It uses the [labels and variables you added to your documents](doc_vars_reference.md) to make an interview that uses the AssemblyLine library.
 
 Through that code, you can also see examples of [docassemble](https://docassemble.org) features you can use other places.
 
@@ -42,9 +37,11 @@ metadata:
 
 
 ## AssemblyLine metadata
-Leave this block as it is if possible. This code block always gets run. The values of these variables affect how your code will work.
+<!-- This might not get done in time, so better to have nothing than something confusing. -->
 
-Some of these variables just hold useful data for possible use in the future. Some are used by your code or the AssemblyLine code.
+<!-- Leave this block as it is if possible. This code block always gets run. The values of these variables affect how your code will work. -->
+
+<!-- Some of these variables be used in the future to help with stuff. Some are used by your code or the AssemblyLine code. -->
 
 1. `title`, `short title`, `description`, `original_form`, and `categories` allow your organization's site to show more information about your form and to organize your forms more easily.
 1. `allowed courts`: Currently used by MassAccess, we may develop this further. It can allow your code to decide which courts to let the user pick from when they need to pick their court.
@@ -248,7 +245,7 @@ Leave this block as it is if possible. Prepares to use this document in the `ALD
 :::info
 What ALDocument does:
 1. Usually you need to attachment blocks for a PDF - a preview without a signature and the final document with a signature. ALDocument takes care of that for you.
-1. It lets you combine files in different ways easily. For example, when sending a packet to the court you might want to add a cover page, but when sending one to the client you might want to include an instruciton sheet instead.
+1. It lets you combine files in different ways easily. For example, when sending a packet to the court you might want to add a cover page, but when sending one to the client you might want to include an instruction sheet instead.
 :::
 
 <!-- 

--- a/docs/weaver_overview.md
+++ b/docs/weaver_overview.md
@@ -1,30 +1,26 @@
 ---
 id: alweaver_overview
-title: AssemblyLine Weaver Code Generator Overview
-sidebar_label: Generating Code
+title: AssemblyLine Weaver overview
+sidebar_label: ALWeaver overview
 slug: /generating_code
 ---
 
-:::note Resources
-- [Edit your PDFs with Documate](https://www.documate.org/pdf)
-- [Use the weaver to generate code](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1)
-- [See the ALWeaver GitHub repository](https://github.com/suffolkLITLab/docassemble-assemblylinewizard)
+<!-- Boilerplate, Baseline, kit, ready to build, some assembly required, something to build on, starting point, blank slate, foundation, groundwork, starter dough, groundwork, spark -->
 
-**Samples**
-- [Sample PDF of the MA Family Law Generic Motion](./assets/generic_motion_family_law.pdf)
-- [Sample DOCX of the MA Family Law Generic Motion](./assets/generic_motion_family_law.docx)
-:::
+You can use the labels and variables of your PDFs and DOCXs in combination with the ALWeaver to help you generate starter code that is ready to work with the AssemblyLine library. You will then be able to edit that code to get the interview you want.
 
-Use your PDFs and DOCXs to help you generate code that will work well with the AssemblyLine library.
+If you have [prepared your PDF or DOCX using certain conventions](doc_vars_reference.md), the weaver will handle the fields it recognizes without further prompting. It will ask questions about the rest of the fields. It will try to recognize fields that ask about people and organizations.
 
-<!-- TODO: Add link to a future page (template overview page?) that lists steps for getting a template ready -->
-
-Once you have your PDF or DOCX file ready:
+To generate the starter code:
+1. If you have a PDF, [add labels to it](doc_vars_reference.md)
 1. [Go to the weaver's page](https://apps-dev.suffolklitlab.org/run/assemblylinewizard/assembly_line/#/1&new_session=1)
 1. Upload your PDF or DOCX
-1. Select the type of each field
-1. Give labels to the individual question fields that the user will see. **Example:** What is your court date?
-1. Build pages with headings, explanatory text, and the fields that will appear there
+1. Select the field type of each field (e.g. text, date, checkbox)
+1. Give labels to the individual question fields that the user will see
+1. Build a page by writing a heading and explanatory text
+1. Pick which fields will go on that page
 
-The anatomy of a generated interview page:
-![One page of an interview made of a heading and explantory text and the fields](./assets/interview_screen_or_page.png)
+A page might look like this:
+![One page of an interview made up of a heading, explantory text, and the fields](./assets/interview_screen_or_page.png)
+
+You can see [the ALWeaver docassemble package on GitHub](https://github.com/suffolkLITLab/docassemble-assemblylinewizard)

--- a/sidebars.js
+++ b/sidebars.js
@@ -6,11 +6,11 @@ module.exports = {
     'name_formats',
     {
       type: 'category',
-      label: 'PDFs and DOCXs',
+      label: 'Generate Code',
       items: [
+        'alweaver_overview',
         'pdfs',
         'document_variables_reference',
-        'alweaver_overview',
         'yaml_anatomy',
       ],
     },


### PR DESCRIPTION
You don't need to review the content (we're planning to do that soon), just make sure it runs. If you do want to review the content, probably pull and run it so you can just look at the actual content.
Test:
- [ ] Runs

- Reorganize side bar and side bar names
- Simplify content as per new doc style guidelines
- Title case for sidebar and page headings
- Add and fix weaver labeling variable conventions inc
  - trial_court
  - dates
  - yes/no
  - separate words
  - mobile number
- Add missing steps to weaver broad overview

Addresses #85. It's also stuff I've been wanting to change for a while.