### PR TITLE
Started rewriting YAML code anatomy

### DIFF
--- a/docs/weaver_code_anatomy.md
+++ b/docs/weaver_code_anatomy.md
@@ -20,8 +20,7 @@ will help.
 An include block incorporates content (code blocks, questions blocks, etc.) from other YAML files. When you run the interview, docassemble acts as if all of the content in the YAML files listed below was copied and pasted right in this exact spot. 
 This is described in more detail in the [docassemble documentation](https://docassemble.org/docs/initial.html#include).
 
-This include block includes the AssemblyLine package, as well as the jurisdiction and organization packages that you picked in the Weaver. By default, the jurisdiction package is ALMassachusetts, and the organization package is the MassAccess package.
-This gives you access to all of the pre-created questions in AssemblyLine.
+This `include` block includes the AssemblyLine package, giving you access to all of the pre-created questions in AssemblyLine. It also adds the jurisdiction and organization packages that you picked in the Weaver. By default, the jurisdiction package is ALMassachusetts, and the organization package is the MassAccess package.
 
 ```yml
 include:
@@ -89,7 +88,7 @@ code: |
 1. `typical role`: controls which questions the user gets asked about themselves and other parties. 
 
 ## Main intro page
-Adds this text to the organization's intro page that appears at the beginning of every interview. This lets your user know right away that they have gotten to the right (or wrong) form. Note that this can (and should) be a more direct and detailed call to action, e.g. ("File a ___" or "Ask the court for ____"), rather than a simple short title, like the short title in the [metadata block](#metadata).
+Adds this text to the organization's intro page that appears at the beginning of every interview. This lets your user know right away that they have gotten to the right (or wrong) form. Note that this can (and should) be a more direct and detailed call to action, e.g. ("File a \_\_\_\_" or "Ask the court for \_\_\_\_"), rather than a simple short title, like the short title in the [metadata block](#metadata).
 
 ```yml
 code: |
@@ -180,8 +179,6 @@ code: |
 
 There is some AssemblyLine code that comes after your own custom interview order code. You will probably leave this code alone as well:
 
-1. `set_parts(subtitle=str(users))` adds to the information a logged in user will listed for this interview in their list of interviews. For an attorney, they should see the name of their clients. For a self represented litigant, they should see their name.
-1. `set_progress()` changes the progress bar shown to the person who's interacting with the form. When they are at the beginning of the form, it should be empty. When they are at the end, other code will make sure it is full. The [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) tries to handle intermediate values between those two places that will make sense to the user. The example interview is short, so intermediate progress is only set once.
 1. `signature_date` is the date that the user signed the form, and is needed on every form that has a signature.
 1. `store_variables_snapshot()` lets you gather data about this interview session. _You should be very thoughtful about what you store, and care must be taken to anonymize it_. Just removing a name is not sufficient.
   

--- a/docs/weaver_code_anatomy.md
+++ b/docs/weaver_code_anatomy.md
@@ -9,11 +9,7 @@ slug: /generated_yaml
 This page is very much under construction as we develop the weaver's capabilities. These 🚧 emoji notes features that are being actively developed in the Weaver and thus might change
 :::
 
-<<<<<<< HEAD
-The code [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) generates is just a starting point. It uses the [labels and variables you added to your documents](doc_vars_reference.md) to make an interview that uses questions and features from the AssemblyLine library.
-=======
-The [ALWeaver](https://apps-test.suffolklitlab.org/start/assemblylinewizard/assembly_line/#/1&new_session=1) generates code that is just a starting point. It uses the [labels and variables you added to your documents](doc_vars_reference.md) to make an interview that uses questions and features from the AssemblyLine library.
->>>>>>> Addressed plocket's comments and suggestions
+The [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) generates code that is a starting point. It uses the [labels and variables you added to your documents](doc_vars_reference.md) to make an interview that uses questions and features from the AssemblyLine library.
 
 This page breaks down what each of these "blocks" (the sections of text that appear between `---`s)
 do individually. You don't have to think about every block as you develop your interview, but as
@@ -156,7 +152,7 @@ code: |
 Code for your custom questions comes next. All your questions should be triggered in here. You will probably make major edits to the code here, changing the order and adding branching logic.
 
 1. `set_parts(subtitle=str(users))` adds to the information a logged in user will see for this interview in their list of interviews. For an attorney, they should see the name of their clients. For a self represented litigant, they should see their name. You can read more about `set_parts` in the [docassemble documentation](https://docassemble.org/docs/functions.html#set_parts).
-1. `set_progress()` changes the progress bar shown to the person who's interacting with the form. When they are at the beginning of the form, it should be empty. When they are at the end, other code will make sure it is full. The [ALWeaver](https://apps-test.suffolklitlab.org/start/assemblylinewizard/assembly_line/#/1&new_session=1) tries to handle intermediate values between those two places that will make sense to the user. The example interview is short, so intermediate progress is only set once.
+1. `set_progress()` changes the progress bar shown to the person who's interacting with the form. When they are at the beginning of the form, it should be empty. When they are at the end, other code will make sure it is full. The [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) tries to handle intermediate values between those two places that will make sense to the user. The example interview is short, so intermediate progress is only set once.
 1. The final variable in the block (`interview_order_a_258e_motion_for_impoundment` above) is customized for your interview. It lets you trigger all the code in this entire code block. In this generated code, the [main order block](#main-order) triggers it. 
 If you are including this interview in another interview, remove the main order block. Then you can use this variable if you want to trigger this particular question order.
 

--- a/docs/weaver_code_anatomy.md
+++ b/docs/weaver_code_anatomy.md
@@ -17,12 +17,14 @@ you use more advanced features of [docassemble](https://docassemble.org), knowin
 will help.
 
 ## Include
-Imports the AssemblyLine package and, 🚧 for now 🚧, the MassAccess package too. As described in the [docassemble documentation](https://docassemble.org/docs/initial.html#include), this incorporates the questions in these two YAML files, as if the contents of those files were copy pasted right in this block. This gives you
-access to all of the pre-created questions in AssemblyLine.
+Imports the AssemblyLine package, and the jurisdiction and organization packages that you checked in the Weaver. By default, the jurisdiction package is ALMassachusetts, and the organization package is  the MassAccess package. 
+As described in the [docassemble documentation](https://docassemble.org/docs/initial.html#include), this incorporates the questions in these YAML files, as if the contents of those files were copy pasted right in this block. 
+This gives you access to all of the pre-created questions in AssemblyLine.
 
 ```yml
 include:
   - docassemble.AssemblyLine:al_package.yml
+  - docassemble.ALMassachusetts:al_massachusetts.yml
   - docassemble.MassAccess:massaccess.yml
 ---
 ```
@@ -57,19 +59,21 @@ code: |
   if not defined("interview_metadata['a_258e_motion_for_impoundment']"):
     interview_metadata.initializeObject('a_258e_motion_for_impoundment')
   interview_metadata['a_258e_motion_for_impoundment'].update({
-    'title': '209a 258e motion for impoundment',
-    'short title': '209a 258e motion for impoundment',
-    'description': '209a 258e motion for impoundment',
-    'original_form': '',
-    'allowed courts': [
-      'Land Court',
+    "al_weaver_version": "0.82",
+    "generated on": "2021-05-28",
+    "title": "209a 258e motion for impoundment",
+    "short title": "209a 258e motion for impoundment",
+    "description": "209a 258e motion for impoundment",
+    "original_form": "",
+    "allowed courts": [
+      "Land Court",
     ],
-    'categories': [
-      'BE-04-00-00-00',
+    "categories": [
+      "BE-04-00-00-00",
     ],
-    'logic block variable': 'a_258e_motion_for_impoundment',
-    'attachment block variable': 'a_258e_motion_for_impoundment_attachment',
-    'typical role': 'plaintiff',
+    "logic block variable": "a_258e_motion_for_impoundment",
+    "attachment block variable": "a_258e_motion_for_impoundment_attachment",
+    "typical role": "plaintiff",
   })
 ---
 ```
@@ -78,13 +82,12 @@ code: |
 1. `original_form` is simply a link to the original, fillable PDF form that this interview is automating, if it exists.
 1. 🚧 `allowed courts` allows your code to decide which courts to let the user pick from when they need to pick their court, usually used in conjunction with [AL Generic Jurisdiction](https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction).
 1. `categories` is the [LIST taxonomy](https://taxonomy.legal/) code for this interview, which can be used by your organization to organize your interviews.
-
 1. `attachment block variable` used to be used in the code that sends documents to courts. It's now deprecated in favor of the [ALDocument object block](#aldocument-object-block)
 1. `logic block variable` is also deprecated
 1. `typical role`: controls which questions the user gets asked, and serves the same purpose as the code in the [interview order block](#interview-order)
 
 ## Main intro page
-Adds this text to the organization's intro page that appears at the beginning of every interview. This lets your user know right away that they have gotten to the right form (or the wrong one). Note that this can (and maybe should) be different from the short title in the [metadata block](#metadata)
+Adds this text to the organization's intro page that appears at the beginning of every interview. This lets your user know right away that they have gotten to the right (or wrong) form. Note that this can (and should) be different from the short title in the [metadata block](#metadata)
 
 ```yml
 code: |
@@ -106,12 +109,12 @@ code: |
 ```
 
 ## Navigation
-[`navigation`](https://docassemble.org/docs/initial.html#navigation%20bar) and [`sections`](https://docassemble.org/docs/initial.html#sections) work with [`nav.set_section()`](https://docassemble.org/docs/functions.html#DANav.show_sections) to show the column on the left that lets your users jump to a screen that lets them edit their information in your interview. Avoids using the 'Back' button which deletes answers.
+[`navigation`](https://docassemble.org/docs/initial.html#navigation%20bar) and [`sections`](https://docassemble.org/docs/initial.html#sections) work with [`nav.set_section()`](https://docassemble.org/docs/functions.html#DANav.show_sections) to show the column on the left that lets your users jump to a screen that lets them edit their information in your interview. 
+Avoids using the 'Back' button which deletes answers.
+
+By default, there is a single "Review" section, that covers the whole interview.
 
 ```yml
-features:
-  navigation: True
----
 sections:
   - review_a_258e_motion_for_impoundment: Review your answers
 ---
@@ -119,8 +122,6 @@ sections:
 
 ## Interview order
 Controls the order in which your screens are shown.
-
-There is a block with the id of `main_order_<name-of-your-interview-here>` that is directly after this block. You shouldn't have to change this code unless you are 🚧 combining multiple interviews together 🚧.
 
 The full interview order block will look something like this. We'll go over each line individually below.
 
@@ -153,12 +154,11 @@ Code for your pages comes next. All your questions should be triggered in here. 
 1. This final variable is customized for your interview. It lets you trigger all the code in this entire code block. If you are including this interview in another interview, you can use this variable to trigger this particular question order. It is also triggered in the [main order block](#main-order)
 
 ## Main Order
+This block controls the higher-level order of the interview, anything that isn't questions specific to your interview, like intro screens, signatures, etc. 
+You shouldn't have to change that code unless you are 🚧 combining multiple interviews together 🚧.
 
 ```yml
 mandatory: True
-comment: |
-  This block includes the logic for standalone interviews.
-  Delete mandatory: True to include in another interview
 id: main_order_a_258e_motion_for_impoundment
 code: |
   al_intro_screen
@@ -179,7 +179,8 @@ There is some AssemblyLine code that comes after your own custom interview order
 
 1. `set_parts(subtitle=str(users))` adds to the information a logged in user will listed for this interview in their list of interviews. For an attorney, they should see the name of their clients. For a self represented litigant, they should see their name.
 1. `set_progress()` changes the progress bar shown to the person who's interacting with the form. When they are at the beginning of the form, it should be empty. When they are at the end, other code will make sure it is full. The [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) tries to handle intermediate values between those two places that will make sense to the user. The example interview is short, so intermediate progress is only set once.
-1. `signature_date` is needed on every form that has a signature (it holds the date that the user is signing the form).
+1. `signature_date` is the date that the user signed the form, and is needed on every form that has a signature.
+1. `store_variables_snapshot()` lets you gather data about this interview session. _You should be very thoughtful  about what you store, and care must be taken to anonymize it_. Just removing a name is not sufficient.
 1. You should be very thoughtful when you use `store_variables_snapshot()`. It lets you gather data about how your form is being used. Care must be taken to anonymize it. Just removing a name is not sufficient.
 1. `a_258e_motion_for_impoundment_preview_question` will trigger [the preview screen](#preview).
 1. `basic_questions_signature_flow` allows the user to pick what device to sign on. This lets them send the form to a smartphone for signing.
@@ -191,8 +192,6 @@ These `question` blocks control the screens your clients will see that are speci
 ### Your interview's intro
 
 ```yml
-comment: |
-  This question is used to introduce your interview. Please customize
 id: 209a 258e motion for impoundment
 continue button field: a_258e_motion_for_impoundment_intro
 question: |
@@ -265,16 +264,9 @@ need: a_258e_motion_for_impoundment
 
 Leave this block as it is if possible. Prepares to use this document in the `ALDocumentBundle`.
 
-:::info
-What ALDocument does:
-
-1. Usually you need to attachment blocks for a PDF - a preview without a signature and the final document with a signature. ALDocument takes care of that for you.
-1. It lets you combine files in different ways easily. For example, when sending a packet to the court you might want to add a cover page, but when sending one to the client you might want to include an instruction sheet instead.
-:::
-
-<!-- 
-1. AssemblyLine is working on ways to help the final download screen present those documents to the user more clearly with less work from the developer.
- -->
+Usually you need to make several different attachment blocks for a PDF: a preview without a signature and the final document with a signature. 
+The ALDocument class takes care of that for you. It also contains some nice features like adding addendums if
+an interviewee's answers are too long.
 
 ```yml
 objects:
@@ -286,6 +278,9 @@ objects:
 
 Leave this block as it is if possible. Adds your file to two 'bundles' automatically - one for the user and one for the court.
 
+The ALDocumentBundle class lets you combine files in different ways easily. For example, when sending a packet to the court you might want to add a cover page, but when sending one to the client you might want to include an instruction sheet instead. With the ALDocumentBundle class, this is as simple as adding the new attachment to the
+`elements` parameter below.
+
 ```yml
 objects:
   - al_user_bundle: ALDocumentBundle.using(elements=[a_258e_motion_for_impoundment_attachment], filename="209a_258e_motion_for_impoundment.pdf", title="All forms to download for your records")
@@ -295,18 +290,20 @@ objects:
 
 ### Attachment block
 
+An [attachment block](https://docassemble.org/docs/documents.html#attachment) for a PDF. This is how you will put your user's answers into a PDF's fields. You will have one for every PDF in your form. Its name is based on your PDF file name.
+
 [How to fill in your PDF fields with docassemble](https://docassemble.org/docs/documents.html#pdf%20template%20file).
 
 ```yml
 attachment:
-    variable name: a_258e_motion_for_impoundment_attachment[i]
     name: 209a 258e motion for impoundment
-    filename: a_258e_motion_for_impoundment
+    filename: a-258e-motion-for-impoundment
+    variable name: a_258e_motion_for_impoundment_attachment[i]
     skip undefined: True
     pdf template file: 209a_258e_motion_for_impoundment.pdf
     fields: 
       - "signature_date": ${ signature_date }
-      # If it is a signature, test which file version we're expecting. leave it empty unless it's the final attachment version
+      # It's a signature: test which file version this is; leave empty unless it's the final version
       - "user_signature": ${ users[0].signature if i == 'final' else '' }
       - "impound_personal_information": ${ impound_personal_information }
       - "impound_case_record_information": ${ impound_case_record_information }
@@ -317,29 +314,6 @@ attachment:
       - "motion_allowed_ex_parte": ${ motion_allowed_ex_parte }
       - "motion_allowed_after_hearing": ${ motion_allowed_after_hearing }
       - "motion_denied": ${ motion_denied }
----
-```
-
-An [attachment block](https://docassemble.org/docs/documents.html#attachment) for a PDF. This is how you will put your user's answers into a PDF's fields. You will have one for every PDF in your form. Its name is based on your PDF file name.
-
-<!-- 
-```yml
-filename: a_258e_motion_for_impoundment
-```
-This is the filename the user will see. Underscores are hard to see in filenames sometimes. You might change this to something like `a-258e-motion-for-impoundment`.
- -->
-
-## ALDocument Object Block
-
-<!-- TODO(brycew): flesh this out more -->
-
-```yml
-objects:
-  - a_258e_motion_for_impoundment_attachment: ALDocument.using(title="258e Motion for Impoundment", filename="a_258e_motion_for_impoundment", enabled=True, has_addendum=False)
----
-objects:
-  - al_user_bundle: ALDocumentBundle.using(elements=[a_258e_motion_for_impoundment_attachment], filename="a_258e_motion_for_impoundment.pdf", title="All forms to download for your records")
-  - al_court_bundle: ALDocumentBundle.using(elements=[a_258e_motion_for_impoundment_attachment], filename="a_258e_motion_for_impoundment.pdf", title="All forms to download for your records")
 ---
 ```
 
@@ -361,3 +335,7 @@ review:
       **Impound personal information**:
       ${ word(yesno(impound_personal_information)) }
 ```
+
+There might be additional blocks that start like `continue button field: users.revisit` or `table: users.table`.
+These blocks are used by the review screen to display and edit multiple pieces of information, like plaintiffs 
+and their contact information.

--- a/docs/weaver_code_anatomy.md
+++ b/docs/weaver_code_anatomy.md
@@ -5,20 +5,26 @@ sidebar_label: View the generated code
 slug: /generated_yaml
 ---
 
-:::warning
+:::caution
 This page is very much under construction as we develop the weaver's capabilities. These 🚧 emoji notes features that are being actively developed in the Weaver and thus might change
 :::
 
+<<<<<<< HEAD
 The code [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) generates is just a starting point. It uses the [labels and variables you added to your documents](doc_vars_reference.md) to make an interview that uses questions and features from the AssemblyLine library.
+=======
+The [ALWeaver](https://apps-test.suffolklitlab.org/start/assemblylinewizard/assembly_line/#/1&new_session=1) generates code that is just a starting point. It uses the [labels and variables you added to your documents](doc_vars_reference.md) to make an interview that uses questions and features from the AssemblyLine library.
+>>>>>>> Addressed plocket's comments and suggestions
 
 This page breaks down what each of these "blocks" (the sections of text that appear between `---`s)
-do individually. You shouldn't have to think about every block as you develop your interview, but as
-you use more advanced features of [docassemble](https://docassemble.org), knowing what these blocks do
+do individually. You don't have to think about every block as you develop your interview, but as
+you use more advanced features of [docassemble](https://docassemble.org/docs.html), knowing more about these blocks 
 will help.
 
 ## Include
-Imports the AssemblyLine package, and the jurisdiction and organization packages that you checked in the Weaver. By default, the jurisdiction package is ALMassachusetts, and the organization package is  the MassAccess package. 
-As described in the [docassemble documentation](https://docassemble.org/docs/initial.html#include), this incorporates the questions in these YAML files, as if the contents of those files were copy pasted right in this block. 
+An include block incorporates content (code blocks, questions blocks, etc.) from other YAML files. When you run the interview, docassemble acts as if all of the content in the YAML files listed below was copied and pasted right in this exact spot. 
+This is described in more detail in the [docassemble documentation](https://docassemble.org/docs/initial.html#include).
+
+This include block includes the AssemblyLine package, as well as the jurisdiction and organization packages that you picked in the Weaver. By default, the jurisdiction package is ALMassachusetts, and the organization package is the MassAccess package.
 This gives you access to all of the pre-created questions in AssemblyLine.
 
 ```yml
@@ -30,7 +36,7 @@ include:
 ```
 
 ## Metadata
-As the comment says, these [metadata block](https://docassemble.org/docs/initial.html#metadata) values control two things:
+These [metadata block](https://docassemble.org/docs/initial.html#metadata) values control two things:
 
 1. the text in this interview's browser tab
 1. the name of the interview on a user's list of saved interviews if they're logged in
@@ -50,9 +56,9 @@ metadata:
 
 ## AssemblyLine metadata
 
+The AssemblyLine metadata block has different, AssemblyLine specific metadata that doesn't fit in the normal [metadata block](#metadata). Additionally, data in this block isn't overwritten if it's included in another interview.
+
 ```yml
-comment: |
-  This section is used by MAVirtualCourts to control how some of the questions work.
 mandatory: True
 code: |
   interview_metadata # make sure we initialize the object
@@ -82,12 +88,12 @@ code: |
 1. `original_form` is simply a link to the original, fillable PDF form that this interview is automating, if it exists.
 1. 🚧 `allowed courts` allows your code to decide which courts to let the user pick from when they need to pick their court, usually used in conjunction with [AL Generic Jurisdiction](https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction).
 1. `categories` is the [LIST taxonomy](https://taxonomy.legal/) code for this interview, which can be used by your organization to organize your interviews.
-1. `attachment block variable` used to be used in the code that sends documents to courts. It's now deprecated in favor of the [ALDocument object block](#aldocument-object-block)
-1. `logic block variable` is also deprecated
-1. `typical role`: controls which questions the user gets asked, and serves the same purpose as the code in the [interview order block](#interview-order)
+1. `attachment block variable` used to be used in the code that sends documents to courts, but now the [ALDocument object block](#aldocument-object-block) is used instead.
+1. `logic block variable` should also no longer be used.
+1. `typical role`: controls which questions the user gets asked about themselves and other parties. 
 
 ## Main intro page
-Adds this text to the organization's intro page that appears at the beginning of every interview. This lets your user know right away that they have gotten to the right (or wrong) form. Note that this can (and should) be different from the short title in the [metadata block](#metadata)
+Adds this text to the organization's intro page that appears at the beginning of every interview. This lets your user know right away that they have gotten to the right (or wrong) form. Note that this can (and should) be a more direct and detailed call to action, e.g. ("File a ___" or "Ask the court for ____"), rather than a simple short title, like the short title in the [metadata block](#metadata).
 
 ```yml
 code: |
@@ -110,9 +116,9 @@ code: |
 
 ## Navigation
 [`navigation`](https://docassemble.org/docs/initial.html#navigation%20bar) and [`sections`](https://docassemble.org/docs/initial.html#sections) work with [`nav.set_section()`](https://docassemble.org/docs/functions.html#DANav.show_sections) to show the column on the left that lets your users jump to a screen that lets them edit their information in your interview. 
-Avoids using the 'Back' button which deletes answers.
+This helps users avoid using the 'Back' button which deletes their answers.
 
-By default, there is a single "Review" section, that covers the whole interview.
+By default, there is a single "Review" section, that covers the whole interview. In longer interviews, adding more sections can show the user a roadmap of what they will have to do and where they are now.
 
 ```yml
 sections:
@@ -145,16 +151,17 @@ code: |
 
 1. `allowed_courts` allows the developer to limit which courts the person filling out the form can pick from, making it easier for them to pick the right court. By default, it's using the same values that are in the [metadata block](#assemblyline-metadata).
 1. `nav.set_section()` comes after `al_intro_screen` and `a_258e_motion_for_impoundment_intro` so that the user can't click to edit their answers before they've actually been asked any questions.
-1. `user_role` tells AssemblyLine which questions to ask about the main party listed on the form.
+1. `user_role` tells AssemblyLine which questions to ask about the main party listed on the form. This should be the same as the `typical role`. However, if `typical role` is `unknown`, then the `user_ask_role` variable will be here instead, and will ask the user what role they have in the case.
 
-Code for your pages comes next. All your questions should be triggered in here. You will probably make major edits to the code here, changing the order and adding branching logic.
+Code for your custom questions comes next. All your questions should be triggered in here. You will probably make major edits to the code here, changing the order and adding branching logic.
 
-1. `set_parts(subtitle=str(users))` adds to the information a logged in user will listed for this interview in their list of interviews. For an attorney, they should see the name of their clients. For a self represented litigant, they should see their name.
+1. `set_parts(subtitle=str(users))` adds to the information a logged in user will see for this interview in their list of interviews. For an attorney, they should see the name of their clients. For a self represented litigant, they should see their name. You can read more about `set_parts` in the [docassemble documentation](https://docassemble.org/docs/functions.html#set_parts).
 1. `set_progress()` changes the progress bar shown to the person who's interacting with the form. When they are at the beginning of the form, it should be empty. When they are at the end, other code will make sure it is full. The [ALWeaver](https://apps-test.suffolklitlab.org/start/assemblylinewizard/assembly_line/#/1&new_session=1) tries to handle intermediate values between those two places that will make sense to the user. The example interview is short, so intermediate progress is only set once.
-1. This final variable is customized for your interview. It lets you trigger all the code in this entire code block. If you are including this interview in another interview, you can use this variable to trigger this particular question order. It is also triggered in the [main order block](#main-order)
+1. The final variable in the block (`interview_order_a_258e_motion_for_impoundment` above) is customized for your interview. It lets you trigger all the code in this entire code block. In this generated code, the [main order block](#main-order) triggers it. 
+If you are including this interview in another interview, remove the main order block. Then you can use this variable if you want to trigger this particular question order.
 
 ## Main Order
-This block controls the higher-level order of the interview, anything that isn't questions specific to your interview, like intro screens, signatures, etc. 
+This block controls the order of things that do not need to be customized for your specific interview, like intro screens, signatures, etc. 
 You shouldn't have to change that code unless you are 🚧 combining multiple interviews together 🚧.
 
 ```yml
@@ -180,8 +187,10 @@ There is some AssemblyLine code that comes after your own custom interview order
 1. `set_parts(subtitle=str(users))` adds to the information a logged in user will listed for this interview in their list of interviews. For an attorney, they should see the name of their clients. For a self represented litigant, they should see their name.
 1. `set_progress()` changes the progress bar shown to the person who's interacting with the form. When they are at the beginning of the form, it should be empty. When they are at the end, other code will make sure it is full. The [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) tries to handle intermediate values between those two places that will make sense to the user. The example interview is short, so intermediate progress is only set once.
 1. `signature_date` is the date that the user signed the form, and is needed on every form that has a signature.
-1. `store_variables_snapshot()` lets you gather data about this interview session. _You should be very thoughtful  about what you store, and care must be taken to anonymize it_. Just removing a name is not sufficient.
-1. You should be very thoughtful when you use `store_variables_snapshot()`. It lets you gather data about how your form is being used. Care must be taken to anonymize it. Just removing a name is not sufficient.
+1. `store_variables_snapshot()` lets you gather data about this interview session. _You should be very thoughtful about what you store, and care must be taken to anonymize it_. Just removing a name is not sufficient.
+  
+  If you want to avoid asking the user for their address, you will need to change the information you save here. This code forces the user's address to be asked.
+
 1. `a_258e_motion_for_impoundment_preview_question` will trigger [the preview screen](#preview).
 1. `basic_questions_signature_flow` allows the user to pick what device to sign on. This lets them send the form to a smartphone for signing.
 1. `users[0].signature` shows the user the signature screen.
@@ -264,7 +273,7 @@ need: a_258e_motion_for_impoundment
 
 Leave this block as it is if possible. Prepares to use this document in the `ALDocumentBundle`.
 
-Usually you need to make several different attachment blocks for a PDF: a preview without a signature and the final document with a signature. 
+Usually you need to make at least two different attachment blocks for a PDF: a preview without a signature and the final document with a signature. 
 The ALDocument class takes care of that for you. It also contains some nice features like adding addendums if
 an interviewee's answers are too long.
 

--- a/docs/weaver_code_anatomy.md
+++ b/docs/weaver_code_anatomy.md
@@ -5,14 +5,20 @@ sidebar_label: View the generated code
 slug: /generated_yaml
 ---
 
-🚧 This page is very much under construction as of 02/17/2021 as we develop the weaver's capabilities. 🚧
+:::warning
+This page is very much under construction as we develop the weaver's capabilities. These 🚧 emoji notes features that are being actively developed in the Weaver and thus might change
+:::
 
-The code [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) generates is just a starting point. It uses the [labels and variables you added to your documents](doc_vars_reference.md) to make an interview that uses the AssemblyLine library.
+The code [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) generates is just a starting point. It uses the [labels and variables you added to your documents](doc_vars_reference.md) to make an interview that uses questions and features from the AssemblyLine library.
 
-Through that code, you can also see examples of [docassemble](https://docassemble.org) features you can use other places.
+This page breaks down what each of these "blocks" (the sections of text that appear between `---`s)
+do individually. You shouldn't have to think about every block as you develop your interview, but as
+you use more advanced features of [docassemble](https://docassemble.org), knowing what these blocks do
+will help.
 
 ## Include
-Imports the AssemblyLine package and, for now, the MassAccess package too. Gives access to the variables in the packages.
+Imports the AssemblyLine package and, 🚧 for now 🚧, the MassAccess package too. As described in the [docassemble documentation](https://docassemble.org/docs/initial.html#include), this incorporates the questions in these two YAML files, as if the contents of those files were copy pasted right in this block. This gives you
+access to all of the pre-created questions in AssemblyLine.
 
 ```yml
 include:
@@ -22,36 +28,25 @@ include:
 ```
 
 ## Metadata
-As the comment says, these [metadata block](https://docassemble.org/docs/initial.html#metadata) values do two things:
-1. Control the text in the browser tab of the interview
-1. Control the name of the interview on a user's list of saved interviews if they're logged in
+As the comment says, these [metadata block](https://docassemble.org/docs/initial.html#metadata) values control two things:
+
+1. the text in this interview's browser tab
+1. the name of the interview on a user's list of saved interviews if they're logged in
+
+You can explore some other settings that you can define here in the [docassemble documentation](https://docassemble.org/docs/initial.html#metadata).
 
 ```yml
-comment: |
-  The metadata section controls the tab title and saved interview title. You can delete this section if you include this YAML file in another YAML file.
 metadata:
   title: |
     209a 258e motion for impoundment
   short title: |
     209a 258e motion for impoundment
+  tags:
+    - BE-04-00-00-00
 ---
 ```
 
-
 ## AssemblyLine metadata
-<!-- This might not get done in time, so better to have nothing than something confusing. -->
-
-<!-- Leave this block as it is if possible. This code block always gets run. The values of these variables affect how your code will work. -->
-
-<!-- Some of these variables be used in the future to help with stuff. Some are used by your code or the AssemblyLine code. -->
-
-1. `title`, `short title`, `description`, `original_form`, and `categories` allow your organization's site to show more information about your form and to organize your forms more easily.
-1. `allowed courts`: Currently used by MassAccess, we may develop this further. It can allow your code to decide which courts to let the user pick from when they need to pick their court.
-
-
-<!-- 1. `typical role`: controls which questions the user gets asked. -->
-<!-- 1. `logic block variable`: Used to trigger the main interview order block that tries to control the order in which questions are asked. -->
-<!-- 1. `attachment block variable`:  -->
 
 ```yml
 comment: |
@@ -70,7 +65,7 @@ code: |
       'Land Court',
     ],
     'categories': [
-      'Guardianship',
+      'BE-04-00-00-00',
     ],
     'logic block variable': 'a_258e_motion_for_impoundment',
     'attachment block variable': 'a_258e_motion_for_impoundment_attachment',
@@ -79,8 +74,17 @@ code: |
 ---
 ```
 
+1. `title`, `short title`, and `description` allow your organization's site to show more information about your form and to organize your forms more easily.
+1. `original_form` is simply a link to the original, fillable PDF form that this interview is automating, if it exists.
+1. 🚧 `allowed courts` allows your code to decide which courts to let the user pick from when they need to pick their court, usually used in conjunction with [AL Generic Jurisdiction](https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction).
+1. `categories` is the [LIST taxonomy](https://taxonomy.legal/) code for this interview, which can be used by your organization to organize your interviews.
+
+1. `attachment block variable` used to be used in the code that sends documents to courts. It's now deprecated in favor of the [ALDocument object block](#aldocument-object-block)
+1. `logic block variable` is also deprecated
+1. `typical role`: controls which questions the user gets asked, and serves the same purpose as the code in the [interview order block](#interview-order)
+
 ## Main intro page
-Adds this text to the organization's intro page that appears at the beginning of every interview. This lets your user know right away that they have gotten to the right form (or the wrong one).
+Adds this text to the organization's intro page that appears at the beginning of every interview. This lets your user know right away that they have gotten to the right form (or the wrong one). Note that this can (and maybe should) be different from the short title in the [metadata block](#metadata)
 
 ```yml
 code: |
@@ -89,7 +93,11 @@ code: |
 ```
 
 ## Case type questions
-Triggers specific AssemblyLine questions depending on its value.
+Changes the wording of AssemblyLine questions depending on it's value. It can be either:
+
+- a court-case type: 'starts_case', 'existing_case', or 'appeal'
+- a letter: 'letter'
+- other: 'other', 'other_form'
 
 ```yml
 code: |
@@ -112,40 +120,58 @@ sections:
 ## Interview order
 Controls the order in which your screens are shown.
 
-There is some AssemblyLine code that comes before your own custom interview order code. You will probably leave this code alone:
+There is a block with the id of `main_order_<name-of-your-interview-here>` that is directly after this block. You shouldn't have to change this code unless you are 🚧 combining multiple interviews together 🚧.
 
-1. `nav.set_section()` comes after `al_intro_screen` and `a_258e_motion_for_impoundment_intro` so that the user can't click to edit their answers before they've actually been asked any questions.
-1. `allowed_courts` is currently connected to MassAccess, but it will be expanded in the future. It allows the developer to limit which courts the person filling out the form can pick from. That makes it easier for them to pick the right court.
-1. `user_role` tells AssemblyLine which questions to ask about the main party listed on the form.
-
-Code for your pages comes next. All your questions should be triggered in here. You will probably make major edits to the code here, changing the order and adding branching logic.
-
-<!-- TODO: Why is `allowed_courts` set lower down as opposed to before all questions or in some separate block? -->
-<!-- TODO: Should `nav.set_section()` come after the first actual question is asked if that's really the purpose? -->
+The full interview order block will look something like this. We'll go over each line individually below.
 
 ```yml
 id: interview_order_a_258e_motion_for_impoundment
 code: |
-  # This is a placeholder to control logic flow in this interview
-  # Intro screen/splash screen
-  al_intro_screen
-  a_258e_motion_for_impoundment_intro
   # Set the allowed courts for this interview
   allowed_courts = interview_metadata["a_258e_motion_for_impoundment"]["allowed courts"]
   nav.set_section('review_a_258e_motion_for_impoundment')
   user_role = 'plaintiff'
   one_of_your_custom_questions
+  users[0].phone_number
   another_of_your_custom_questions
   # Set the answer file name.
   set_parts(subtitle=str(users))
   set_progress(16.67)
+  trial_court.division
+  interview_order_a_258e_motion_for_impoundment = True
+---
+```
+
+1. `allowed_courts` allows the developer to limit which courts the person filling out the form can pick from, making it easier for them to pick the right court. By default, it's using the same values that are in the [metadata block](#assemblyline-metadata).
+1. `nav.set_section()` comes after `al_intro_screen` and `a_258e_motion_for_impoundment_intro` so that the user can't click to edit their answers before they've actually been asked any questions.
+1. `user_role` tells AssemblyLine which questions to ask about the main party listed on the form.
+
+Code for your pages comes next. All your questions should be triggered in here. You will probably make major edits to the code here, changing the order and adding branching logic.
+
+1. `set_parts(subtitle=str(users))` adds to the information a logged in user will listed for this interview in their list of interviews. For an attorney, they should see the name of their clients. For a self represented litigant, they should see their name.
+1. `set_progress()` changes the progress bar shown to the person who's interacting with the form. When they are at the beginning of the form, it should be empty. When they are at the end, other code will make sure it is full. The [ALWeaver](https://apps-test.suffolklitlab.org/start/assemblylinewizard/assembly_line/#/1&new_session=1) tries to handle intermediate values between those two places that will make sense to the user. The example interview is short, so intermediate progress is only set once.
+1. This final variable is customized for your interview. It lets you trigger all the code in this entire code block. If you are including this interview in another interview, you can use this variable to trigger this particular question order. It is also triggered in the [main order block](#main-order)
+
+## Main Order
+
+```yml
+mandatory: True
+comment: |
+  This block includes the logic for standalone interviews.
+  Delete mandatory: True to include in another interview
+id: main_order_a_258e_motion_for_impoundment
+code: |
+  al_intro_screen
+  a_258e_motion_for_impoundment_intro
+  # Interview order block has form-specific logic controlling order/branching
+  interview_order_a_258e_motion_for_impoundment_intro
   signature_date
   # Save (anonymized) interview statistics.
   store_variables_snapshot(data={'zip': users[0].address.zip})
-  a_258e_motion_for_impoundment_preview_question # Pre-canned preview screen
+  a_258e_motion_for_impoundment_preview_question  # Pre-canned preview screen
   basic_questions_signature_flow
   users[0].signature
-  a_258e_motion_for_impoundment = True
+  a_258e_motion_for_impoundment_download
 ---
 ```
 
@@ -153,13 +179,11 @@ There is some AssemblyLine code that comes after your own custom interview order
 
 1. `set_parts(subtitle=str(users))` adds to the information a logged in user will listed for this interview in their list of interviews. For an attorney, they should see the name of their clients. For a self represented litigant, they should see their name.
 1. `set_progress()` changes the progress bar shown to the person who's interacting with the form. When they are at the beginning of the form, it should be empty. When they are at the end, other code will make sure it is full. The [ALWeaver](https://apps-test.suffolklitlab.org/start/ALWeaver/assembly_line/#/1&new_session=1) tries to handle intermediate values between those two places that will make sense to the user. The example interview is short, so intermediate progress is only set once.
-1. `signature_date` is needed on every form that we know of.
+1. `signature_date` is needed on every form that has a signature (it holds the date that the user is signing the form).
 1. You should be very thoughtful when you use `store_variables_snapshot()`. It lets you gather data about how your form is being used. Care must be taken to anonymize it. Just removing a name is not sufficient.
 1. `a_258e_motion_for_impoundment_preview_question` will trigger [the preview screen](#preview).
 1. `basic_questions_signature_flow` allows the user to pick what device to sign on. This lets them send the form to a smartphone for signing.
 1. `users[0].signature` shows the user the signature screen.
-1. This final variable is customized for your interview. It lets you trigger all the code in this entire code block. If you are including this interview in another interview, you can use this variable to trigger this particular question order.
-
 
 ## Your screens
 These `question` blocks control the screens your clients will see that are specific to your interview.
@@ -195,7 +219,6 @@ subquestion: |
 ---
 ```
 
-
 ## Your questions
 [Question blocks](https://docassemble.org/docs/questions.html) will show screens with information and questions. You will probably edit these blocks as you identify your needs and the needs of the people using your tools.
 
@@ -217,7 +240,6 @@ fields:
 ---
 ```
 
-
 ## Download
 Users will be able to download or email the form. They may sometimes be able to submit it to the court.
 
@@ -237,7 +259,6 @@ need: a_258e_motion_for_impoundment
 ---
 ```
 
-
 ## Attachments
 
 ### ALDocument
@@ -246,6 +267,7 @@ Leave this block as it is if possible. Prepares to use this document in the `ALD
 
 :::info
 What ALDocument does:
+
 1. Usually you need to attachment blocks for a PDF - a preview without a signature and the final document with a signature. ALDocument takes care of that for you.
 1. It lets you combine files in different ways easily. For example, when sending a packet to the court you might want to add a cover page, but when sending one to the client you might want to include an instruction sheet instead.
 :::
@@ -306,6 +328,20 @@ filename: a_258e_motion_for_impoundment
 ```
 This is the filename the user will see. Underscores are hard to see in filenames sometimes. You might change this to something like `a-258e-motion-for-impoundment`.
  -->
+
+## ALDocument Object Block
+
+<!-- TODO(brycew): flesh this out more -->
+
+```yml
+objects:
+  - a_258e_motion_for_impoundment_attachment: ALDocument.using(title="258e Motion for Impoundment", filename="a_258e_motion_for_impoundment", enabled=True, has_addendum=False)
+---
+objects:
+  - al_user_bundle: ALDocumentBundle.using(elements=[a_258e_motion_for_impoundment_attachment], filename="a_258e_motion_for_impoundment.pdf", title="All forms to download for your records")
+  - al_court_bundle: ALDocumentBundle.using(elements=[a_258e_motion_for_impoundment_attachment], filename="a_258e_motion_for_impoundment.pdf", title="All forms to download for your records")
+---
+```
 
 ## Review screen
 The 'Back' button deletes answers as the user goes farther back. When they press to continue, they will have to fill in their answers again. The review screen lets them edit their answers without deleting any of them.


### PR DESCRIPTION
Updated the YAML code anatomy page as best I could in a few passes. Definitely not perfect, but more aiming to get something down concretely right now as opposed to a fully-formed document.

To consider: don't document as much of this file as we currently do, or it's just going to get stale faster. Keep the important stuff (interview order, main order, questions, and maybe objects), and ignore most of the other stuff?

Resolves #44.