### PR TITLE
Give pydoc-markdown a category name, integrate it into sidebar

### DIFF
--- a/docs/reference/sidebar.json
+++ b/docs/reference/sidebar.json
@@ -1,5 +1,9 @@
-[
-  "reference/al_general",
-  "reference/al_courts",
-  "reference/al_document"
-]
+{
+  "items": [
+    "reference/al_courts",
+    "reference/al_document",
+    "reference/al_general"
+  ],
+  "label": "API Reference",
+  "type": "category"
+}

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -11,4 +11,4 @@ renderer:
   docs_base_path: docs
   relative_output_path: reference
   relative_sidebar_path: sidebar.json
-  sidebar_top_level_label: null
+  sidebar_top_level_label: "API Reference"

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,6 +1,6 @@
 module.exports = {
-  someSidebar: {
-    'Using the AssemblyLine Framework': ['intro',
+  someSidebar: [
+    'intro',
     'bootcamp',
     'getting_started',
     {
@@ -17,7 +17,6 @@ module.exports = {
     'github',
     'name_formats',
     'docs_style_guide',
-    ],	
-    "API Documentation": require("./docs/reference/sidebar.json")
-  },
+    require('./docs/reference/sidebar.json')
+  ],
 };


### PR DESCRIPTION
FIxes the issues with #129, lets you just run pydoc-markdown without changing the UI again. pydoc-markdown generates a very different `sidebar.json` depending on if there's a top level label provided; it's not very well documented, but is [in the source code](https://github.com/NiklasRosenstein/pydoc-markdown/blob/c974c22cd2ece05b86faa783a68526cc7cb61322/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py#L128). 

Also changed the sidebar to be closer to what @plocket suggested: with only the API Reference in a dropdown.

![Screenshot from 2021-06-02 13-02-05](https://user-images.githubusercontent.com/6252212/120524329-f22cb080-c3a4-11eb-8e0a-e992377ade17.png)

Longer term, we might want to organize the docs around the [divio documentation system](https://documentation.divio.com/), but that's out of scope here. I should make an issue for it.