### PR TITLE
Close #93, automatically deploy documentation on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+# Based on https://docusaurus.io/docs/deployment#triggering-deployment-with-github-actions
+# At times doesn't fail, even when deployment is broken
+name: Deploy documentation to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          cache: npm
+      - name: Build website
+        run: |
+          npm ci
+          npm run build
+
+      # Popular action to deploy to GitHub Pages:
+      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./build
+          # Assign commit authorship to the official GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,23 @@
+# Based on https://docusaurus.io/docs/deployment#triggering-deployment-with-github-actions
+# At times doesn't fail, even when deployment is broken
+name: Test deployment of documentation
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test-deploy:
+    name: Test deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          cache: npm
+      - name: Test build
+        run: |
+          npm ci
+          npm run build


### PR DESCRIPTION
## Still to do

It works as it is now, but we should decide if we want to put someone's username and email in deploy.yml. Feel free to edit that in if you want it.

## More info

Also runs a test deploy when a PR is made to main. Both workflows are based on docusaurus code that's linked in #93.

I tested it on a fork and all seemed well. That said, I'm not sure how well the actions communicate. For example, they didn't error when a non-existent directory was referenced, just created a 404 with no clues.

In addition to the docusaurus code, I've added the ability to manually trigger both the test and the deployment of main, for whatever good that does.

Note: This might only start working once it's been merged with main.

Closes #93