### PR TITLE
Undo complication of `npm run start`. Originally the change seemed

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "npm run build && docusaurus start",
+    "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
to fix something that was broken, but it seems to me now that it
was caused by something else.

Not sure if I need a review for this before merging.