### PR TITLE
Restore css (spacing) to original, add custom image styling to...

### DIFF
--- a/docs/automated_testing.md
+++ b/docs/automated_testing.md
@@ -60,7 +60,7 @@ GitHub lets you disable workflow files like these. See their instructions at htt
 
 You can also delete the file from your repository completely. If you go to the front page of your repository, the file is in the `workflows` folder of the `.github` folder. It's called `run_form_tests.yml`. GitHub's instructions about how to delete a file are at https://docs.github.com/en/repositories/working-with-files/managing-files/deleting-files-in-a-repository.
 
-Another option is to disable or limiting all tests, all actions, in your repository. GitHub's documentation for managing repository actions is at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository.
+Another option is to disable or limit all tests, all actions, in your repository. GitHub's documentation for managing repository actions is at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository.
 
 #### Disabling tests for the whole organization
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -1,9 +1,14 @@
 ---
 id: github
-title: Using Github with docassemble
-sidebar_label: Github tutorials
+title: Using GitHub with docassemble
+sidebar_label: GitHub tutorials
 slug: /github
 ---
+
+import styles from "../src/css/images.module.css"
+
+<div className={ styles.medium_width }>
+
 <!-- original: https://docs.google.com/document/d/1pj1DFIhzzwB6raeCytnmPSR41WfNvG-T9GYPsf1wOsA/edit -->
 
 Ways to use GitHub in combination with docassemble. GitHub itself has decent documentation for its own features.
@@ -726,3 +731,5 @@ If you do not have write permissions on a repository, you can still see play wit
 When you make a pull request from one branch of your fork to another branch of your fork, make sure the chosen branches in the dropdowns are correct. GitHub will automatically set your pull request to use the original owner's repository instead of your own.
 
 If you later do want to offer your changes to the owner of the original repository, you can [make a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
+
+</div>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,13 +15,8 @@
   --ifm-color-primary-lighter: rgb(102, 212, 189);
   --ifm-color-primary-lightest: rgb(146, 224, 208);
   --ifm-code-font-size: 95%;
-  --doc-sidebar-width: 15em !important;
-  --ifm-container-width: 100vw;
-  --ifm-leading: 0.2em;
-}
-
-.container.docItemWrapper_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocPage- {
-  max-width: calc( var(--ifm-container-width) - var(--doc-sidebar-width) );
+  /* Give center section more room */
+  /*--doc-sidebar-width: 15em !important;*/
 }
 
 .docusaurus-highlight-code-line {
@@ -29,42 +24,4 @@
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
-}
-
-.container {
-  margin: 0;
-}
-
-.markdown h2 {
-  border-top: 2px solid var(--ifm-hr-border-color);
-  padding-top: calc(1.5 * var(--ifm-h2-vertical-rhythm-top) * var(--ifm-leading));
-  margin-top: calc(2 * var(--ifm-h2-vertical-rhythm-top) * var(--ifm-leading));
-  margin-bottom: calc(1.5 * var(--ifm-heading-vertical-rhythm-bottom) * var(--ifm-leading) );
-}
-
-.markdown h3 {
-  margin-top: calc(2.5 * var(--ifm-h3-vertical-rhythm-top) * var(--ifm-leading));
-  margin-bottom: calc( 2 * var(--ifm-heading-vertical-rhythm-bottom) * var(--ifm-leading) );
-}
-
-.markdown>h4,
-.markdown>h5,
-.markdown>h6 {
-  margin-top: calc(4 * var(--ifm-heading-vertical-rhythm-top) * var(--ifm-leading));
-}
-
-img {
-  border: 2px solid var(--ifm-color-secondary);
-  border-radius: 3px;
-  max-width: 75%;
-}
-
-p {
-  margin: 0 0 calc(3 * var(--ifm-paragraph-margin-bottom));
-}
-
-.markdown > pre,
-.markdown > ul,
-.markdown > p {
-  margin-bottom: calc(3 * var(--ifm-leading));
 }

--- a/src/css/images.module.css
+++ b/src/css/images.module.css
@@ -1,0 +1,7 @@
+/* The github tutorials page has a lot of images and we want
+*    to keep their size under control more easily.  */
+.medium_width img {
+  border: 2px solid var(--ifm-color-secondary);
+  border-radius: 3px;
+  max-width: 75%;
+}


### PR DESCRIPTION
GitHub tutorial page. This makes the left sidebar wider and therefore
the content more narrow. I left a commented-out line in there to
change it back if we want.

[Apparently other stuff snuck in there too. Sorry about that it's just github tutorial and testing stuff and I'm happy with it, so it can be ignored.]

[Closes #158 if you like this]