### PR TITLE
Add Google Analytics (v4) to the site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -112,6 +112,10 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          trackingID: 'G-622Z2D6Q3Q',
+          anonymizeIP: true
+        }
       },
     ],
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "2.0.0-beta.20",
         "@docusaurus/mdx-loader": "^2.0.0-beta.20",
+        "@docusaurus/plugin-google-gtag": "^2.0.0-beta.20",
         "@docusaurus/plugin-ideal-image": "^2.0.0-beta.20",
         "@docusaurus/preset-classic": "2.0.0-beta.20",
         "@easyops-cn/docusaurus-search-local": "^0.23.2",
@@ -2238,6 +2239,23 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
+    "node_modules/@docusaurus/plugin-google-gtag": {
+      "version": "2.0.0-beta.20",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.20.tgz",
+      "integrity": "sha512-EMZdiMTNg4NwE60xwjbetcqMDqAOazMTwQAQ4OuNAclv7oh8+VPCvqRF8s8AxCoI2Uqc7vh8yzNUuM307Ne9JA==",
+      "dependencies": {
+        "@docusaurus/core": "2.0.0-beta.20",
+        "@docusaurus/utils-validation": "2.0.0-beta.20",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
     "node_modules/@docusaurus/plugin-ideal-image": {
       "version": "2.0.0-beta.20",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-ideal-image/-/plugin-ideal-image-2.0.0-beta.20.tgz",
@@ -2509,23 +2527,6 @@
       "version": "2.0.0-beta.20",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.20.tgz",
       "integrity": "sha512-4C5nY25j0R1lntFmpSEalhL7jYA7tWvk0VZObiIxGilLagT/f9gWPQtIjNBe4yzdQvkhiaXpa8xcMcJUAKRJyw==",
-      "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.20",
-        "@docusaurus/utils-validation": "2.0.0-beta.20",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.20.tgz",
-      "integrity": "sha512-EMZdiMTNg4NwE60xwjbetcqMDqAOazMTwQAQ4OuNAclv7oh8+VPCvqRF8s8AxCoI2Uqc7vh8yzNUuM307Ne9JA==",
       "dependencies": {
         "@docusaurus/core": "2.0.0-beta.20",
         "@docusaurus/utils-validation": "2.0.0-beta.20",
@@ -14970,6 +14971,16 @@
         "webpack": "^5.72.0"
       }
     },
+    "@docusaurus/plugin-google-gtag": {
+      "version": "2.0.0-beta.20",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.20.tgz",
+      "integrity": "sha512-EMZdiMTNg4NwE60xwjbetcqMDqAOazMTwQAQ4OuNAclv7oh8+VPCvqRF8s8AxCoI2Uqc7vh8yzNUuM307Ne9JA==",
+      "requires": {
+        "@docusaurus/core": "2.0.0-beta.20",
+        "@docusaurus/utils-validation": "2.0.0-beta.20",
+        "tslib": "^2.4.0"
+      }
+    },
     "@docusaurus/plugin-ideal-image": {
       "version": "2.0.0-beta.20",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-ideal-image/-/plugin-ideal-image-2.0.0-beta.20.tgz",
@@ -15162,16 +15173,6 @@
           "version": "2.0.0-beta.20",
           "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.20.tgz",
           "integrity": "sha512-4C5nY25j0R1lntFmpSEalhL7jYA7tWvk0VZObiIxGilLagT/f9gWPQtIjNBe4yzdQvkhiaXpa8xcMcJUAKRJyw==",
-          "requires": {
-            "@docusaurus/core": "2.0.0-beta.20",
-            "@docusaurus/utils-validation": "2.0.0-beta.20",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/plugin-google-gtag": {
-          "version": "2.0.0-beta.20",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.20.tgz",
-          "integrity": "sha512-EMZdiMTNg4NwE60xwjbetcqMDqAOazMTwQAQ4OuNAclv7oh8+VPCvqRF8s8AxCoI2Uqc7vh8yzNUuM307Ne9JA==",
           "requires": {
             "@docusaurus/core": "2.0.0-beta.20",
             "@docusaurus/utils-validation": "2.0.0-beta.20",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.20",
     "@docusaurus/mdx-loader": "^2.0.0-beta.20",
+    "@docusaurus/plugin-google-gtag": "^2.0.0-beta.20",
     "@docusaurus/plugin-ideal-image": "^2.0.0-beta.20",
     "@docusaurus/preset-classic": "2.0.0-beta.20",
     "@easyops-cn/docusaurus-search-local": "^0.23.2",


### PR DESCRIPTION
Followed the instructions in: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag

Adding the analytics ID to the public repo like this doesn't have any negative consequences, since normally IDs are public (sent through the page's HTML) anyway.