### PR TITLE
Move code_style docs to one folder

### DIFF
--- a/docs/coding_style/code_style_guide_notes_not_published.md
+++ b/docs/coding_style/code_style_guide_notes_not_published.md
@@ -10,20 +10,16 @@
 
 [We can probably find existing samples to start with?]
 
-
-
 *   [https://www.pullrequest.com/blog/create-a-programming-style-guide/](https://www.pullrequest.com/blog/create-a-programming-style-guide/)
 *   [https://medium.com/level-up-web/what-is-a-programming-style-guide-and-why-should-you-care-9019e51bb7ad](https://medium.com/level-up-web/what-is-a-programming-style-guide-and-why-should-you-care-9019e51bb7ad)
 
 Why do we want conventions and guidelines
 
 
-
 *   We want to make it easy for anyone to pick up someone else’s code and to keep working on it
 *   Help new coders who don’t have any way to code yet to choose a way. Reduce decision paralysis.
 
 Overall goals: 
-
 
 
 *   This is a document to help our team come to consensus so that we each teach people how to do things the same way.
@@ -179,11 +175,8 @@ How much of this is being handled in Trello? What should be kept there and what 
 
 ### 5.9 TODO: Amend checklist {#5-9-todo-amend-checklist}
 
-
-
 *   A practice of creating a new Playground Project for each interview
 *   A practice of creating a decision log for each form
-
 
 
 ### 5.14 Proposal: process_action() and other one-use-per-interview functionalities {#5-14-proposal-process_action-and-other-one-use-per-interview-functionalities}
@@ -191,12 +184,11 @@ How much of this is being handled in Trello? What should be kept there and what 
 There is a list needed here, but some things should only be done once per interview. For those things we should implement a variable that is a flag for making sure they are only run once. Use would look like this:
 
 
-```
+```python
 if not did_this_thing:
   do_this_thing()
   did_this_thing = True
 ```
-
 
 Proposal: we use `did_` at the beginning of every one of these flags.
 
@@ -215,6 +207,3 @@ Proposal: we use `did_` at the beginning of every one of these flags.
    </td>
   </tr>
 </table>
-
-
-

--- a/docs/coding_style/coding_style_overview.md
+++ b/docs/coding_style/coding_style_overview.md
@@ -1,5 +1,5 @@
 ---
-id: coding_style
+id: coding_style_overview
 title: Docassemble Coding Style Guide
 sidebar_label: Coding Style
 slug: /coding_style_guide

--- a/docs/coding_style/defense.md
+++ b/docs/coding_style/defense.md
@@ -1,5 +1,5 @@
 ---
-id: coding_style_defense
+id: defense
 title: |
    "Safe" coding
 sidebar_label: |
@@ -10,12 +10,12 @@ slug: /coding_style_guide/defense
 ## Use Docassemble lists, dictionaries, and sets, or subclasses
 
 Docassemble relies heavily on exceptions for its declarative logic
-system. Those work better with the DAObject class and classes that 
+system. Those work better with the DAObject class and classes that
 inherit from it. Docassemble's DAObject class adds an `intrinsicName`
 attribute to every object that helps Docassemble track down a question
 that is able to define a variable.
 
-Where you make uses of lists, dictionaries, or sets, you should 
+Where you make uses of lists, dictionaries, or sets, you should
 default to using either a DAList, DADict, or DASet, or a class that
 inherits from one of those classes.
 
@@ -78,6 +78,7 @@ with collections that you know which datastructure you are using.
 
 When you create a function that accepts a list, you may want to explicitly
 convert to a list before working with it in case a developer passes in a `set`.
+
 ## Check for None
 
 It is common for Python functions to return `None` in certain error
@@ -91,6 +92,6 @@ Docassemble are for convenience and your user should be able to continue in some
 fashion. You should never drop down to a Docassemble error screen when an
 external dependency fails or is unavailable.
 
-# Further reading and sources
+## Further reading and sources
 
 * [Defensive Programming](https://en.wikipedia.org/wiki/Defensive_programming), Wikipedia

--- a/docs/coding_style/docs_style_guide.md
+++ b/docs/coding_style/docs_style_guide.md
@@ -100,7 +100,7 @@ Reference-style: ![alt text][logo]
 
 Images from any folder can be used by providing path to file. Path should be relative to markdown file.
 
-![img](../static/img/logo.svg)
+![img](../../static/img/logo.svg)
 
 ---
 

--- a/docs/coding_style/python.md
+++ b/docs/coding_style/python.md
@@ -1,5 +1,5 @@
 ---
-id: coding_style_python
+id: python
 title: Python
 sidebar_label: Python
 slug: /coding_style_guide/python

--- a/docs/coding_style/yaml.md
+++ b/docs/coding_style/yaml.md
@@ -1,5 +1,5 @@
 ---
-id: coding_style_yaml
+id: yaml
 title: Interview files
 sidebar_label: Interview files
 slug: /coding_style_guide/yaml
@@ -21,7 +21,7 @@ your code.
 
 ## Use Python conventions for variable names and Python code in your YAML files
 
-See [Python style guide](coding_style_python.md).
+See [Python style guide](python.md).
 
 ## Organize and name your files
 
@@ -85,12 +85,12 @@ adding additional files when:
 
 1. you want to use an interview like a module inside another interview
 1. your YAML file is thousands of lines long and you have clear functional
-   separation between each file. For example: code, style, questions; or 
+   separation between each file. For example: code, style, questions; or
    maybe "eviction", "appeals", "bad_housing_conditions".
 1. you need to split work between multiple developers and you are running into
    challenges with overwriting each others' work
 1. you need non-technical members of your team to be able to make changes with
-   confidence. You might choose to separate code from question language, in that 
+   confidence. You might choose to separate code from question language, in that
    case.
 
 ### Use clear filenames for modular interview files

--- a/docs/coding_style/yaml_dynamic.md
+++ b/docs/coding_style/yaml_dynamic.md
@@ -1,5 +1,5 @@
 ---
-id: coding_style_yaml_dynamic
+id: yaml_dynamic
 title: Making your interview dynamic
 sidebar_label: Making your interview dynamic
 slug: /coding_style_guide/yaml_dynamic

--- a/docs/coding_style/yaml_interface.md
+++ b/docs/coding_style/yaml_interface.md
@@ -1,11 +1,11 @@
 ---
-id: coding_style_yaml_interface
+id: yaml_interface
 title: Choosing interface options
 sidebar_label: Choosing interface options
 slug: /coding_style_guide/yaml_interface
 ---
 
-### Use radio buttons for short lists of options
+## Use radio buttons for short lists of options
 
 When the user has only one valid choice among a relatively short list,
 use radio buttons. Use a dropdown menu in situations where:
@@ -13,7 +13,7 @@ use radio buttons. Use a dropdown menu in situations where:
 1. the list of choices is longer than about 7 options
 1. the choice is optional and not very common (such as a name suffix)
 
-### Have a "next" or "continue" button on most screens
+## Have a "next" or "continue" button on most screens
 
 Docassemble has a "yesno" question type that replaces the "Continue" button
 with buttons that immediately move to the next screen. This feature
@@ -43,7 +43,7 @@ included by default in the Assembly Line package.
 Use the `collapse_template()` function with a `template` block to add
 in-context explanatory text in the `subquestion` of your question block.
 
-Example: 
+Example:
 
 ```yaml
 ---
@@ -64,22 +64,25 @@ template: overpayment_waiver_help_template
 subject: |
   More information about an overpayment waiver
 content: |
-  When Social Security says that you have an overpayment they are saying that you got more SSI or SSDI than you should have gotten under their rules. The reason Social Security says you have an overpayment is in the Notice of Overpayment. 
+  When Social Security says that you have an overpayment they are saying that
+  you got more SSI or SSDI than you should have gotten under their rules. The
+  reason Social Security says you have an overpayment is in the Notice of 
+  Overpayment. 
 ```
 
 Docassemble has many features that allow you to add help
 in-context. They include:
 
-1. the question help button
-1. the glossary `terms` feature
+1. the [question help button](https://docassemble.org/docs/modifiers.html#help)
+1. the [glossary `terms` feature](https://docassemble.org/docs/modifiers.html#terms)
 1. the `under` area
-1. the field `hint` modifier that adds placeholder text
-1. the field `help` modifier
-1. the option `help` modifier
+1. the [field `hint` modifier](https://docassemble.org/docs/fields.html#hint) that adds placeholder text
+1. the [field `help` modifier](https://docassemble.org/docs/fields.html#help)
+1. the [option `help` modifier](https://docassemble.org/docs/fields.html#field%20with%20choices)
 
 Through expert feedback, we have determined that the question help button should
 never be used. The placement of the button and the use of a separate mode for
-help text can be confusing. Help may also come "too late" with this feature, 
+help text can be confusing. Help may also come "too late" with this feature,
 after a user has already completed answering the questions on screen.
 
 We also discourage use of the `hint` modifier that adds placeholder text to a
@@ -99,3 +102,5 @@ The `field` and `option` help modifiers are both relatively clear and simple to
 use for field-specific hints and to explain choices that may otherwise not be
 clear. Custom CSS may make these features slightly more polished than the
 stock Docassemble appearance.
+
+## 

--- a/docs/coding_style/yaml_lists.md
+++ b/docs/coding_style/yaml_lists.md
@@ -1,5 +1,5 @@
 ---
-id: coding_style_yaml_lists
+id: yaml_lists
 title: Collecting items in lists
 sidebar_label: Collecting items in lists
 slug: /coding_style_guide/yaml_lists
@@ -8,10 +8,16 @@ slug: /coding_style_guide/yaml_lists
 ## Guiding Principles
 
 Try to gather items in a list in a way that would be natural to do in a
-conversation. For example: if you ask about income, you might naturally ask: do
-you work? Do you have any other jobs? Do you have any pension income? If you ask
-about children, it may be more natural to ask: do you have any children? How
-many? And then ask for the information of each child one at at a time. In other
+conversation. For example: if you ask about income, you might naturally ask:
+* do you work?
+* do you have any other jobs?
+* do you have any pension income?  
+
+If you ask about children, it may be more natural to ask:
+* do you have any children?
+* how many?
+
+And then ask for the information of each child one at at a time. In other
 circumstances, it may be simpler to let someone interact with a button to add
 additional items, one at a time where they can see the full list they have
 entered at the same time that they add new items.
@@ -53,7 +59,7 @@ Consider adding a table or list of the children at the end as a summary/check
 that they did the entry correctly.
 
 
-#### Ask for items with the "list collect" feature
+### Ask for items with the "list collect" feature
 
 Appropriate when adding multiple items is not likely, the user does not
 necessarily know the total number of items in advance or asking for a total

--- a/docs/coding_style/yaml_structure.md
+++ b/docs/coding_style/yaml_structure.md
@@ -1,5 +1,5 @@
 ---
-id: coding_style_yaml_structure
+id: yaml_structure
 title: Structuring your interview
 sidebar_label: Structuring your interview
 slug: /coding_style_guide/yaml_structure

--- a/docs/coding_style/yaml_translation.md
+++ b/docs/coding_style/yaml_translation.md
@@ -1,5 +1,5 @@
 ---
-id: coding_style_yaml_translation
+id: yaml_translation
 title: Planning for translation and flexible updates
 sidebar_label: Planning for translation
 slug: /coding_style_guide/yaml_translation
@@ -72,7 +72,7 @@ language: es
 sections:
   - Sección 1
   - Sección 2
-```    
+```
 
 ### Avoid using the language functions from `pattern.en` in your interview
 

--- a/docs/doc_vars_reference.md
+++ b/docs/doc_vars_reference.md
@@ -15,6 +15,7 @@ that we list below for full compatibility.
 - [The DOCX version of the same motion](./assets/generic_motion_family_law.docx)
 
 ## The basics
+
 ### Fields, labels, and variables
 
 A blank space on a paper form is usually called a `form field`, or `field` for
@@ -33,7 +34,7 @@ rules below to add as many custom labels as you need.
 #### Labels should be valid Python variable names that start with a letter
 
 PDF and DOCX `labels` should also work as valid [Python variable
-names](coding_style_python.md). The basic rule is that Python variable names
+names](coding_style/python.md). The basic rule is that Python variable names
 need to start with a letter and can only contain letters, digits, and the `_`
 underscore character. Some variable names are
 [reserved](framework/reserved_keywords.md) and have a special meaning inside

--- a/docs/question_style_help_your_user.md
+++ b/docs/question_style_help_your_user.md
@@ -7,7 +7,7 @@ slug: /style_guide/question_help_your_user
 
 ## Provide help information in context
 
-Use the [help options](coding_style_yaml_interface.md#adding-help-in-context)
+Use the [help options](coding_style/yaml_interface.md#adding-help-in-context)
 that your interview platform offers. Not all users will need the same help.
 Too much information on screen can be confusing.
 
@@ -111,4 +111,4 @@ Instead, you may just want to provide help text that suggests
 how the user should fill the field.
 
 For example, allow space for the user to provide information like phone numbers
-and addreses that are from a different country.
+and addresses that are from a different country.

--- a/docs/style_guide_formatting.md
+++ b/docs/style_guide_formatting.md
@@ -18,13 +18,13 @@ A heading should only be about one line of text on the screen.
 
 ### Keep text short in general
 Some users struggle to read large amounts of text on the screen. Keep the text
-short and to the point. You can add more information with the [progresive disclosure
-element](coding_style_yaml_interface.md).
+short and to the point. You can add more information with the [progressive disclosure
+element](coding_style/yaml_interface.md).
 
 ### Only use all capital letters for acronyms
 
 For example, the Department of Children and Families (DCF), Transitional
-Assistance for Families and Dependent Children (TAFDC). 
+Assistance for Families and Dependent Children (TAFDC).
 
 ### Use bold for emphasis. Avoid underlines, italics, or all capital letters
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -59,15 +59,15 @@ module.exports = {
             type: 'category',
             label: 'Coding Style Guide',
             items: [
-                'coding_style',
-                'coding_style_python',
-                'coding_style_yaml',
-                'coding_style_yaml_structure',
-                'coding_style_yaml_dynamic',
-                'coding_style_yaml_interface',
-                'coding_style_yaml_translation',
-                'coding_style_defense',
-                'docs_style_guide'
+                'coding_style/coding_style_overview',
+                'coding_style/python',
+                'coding_style/yaml',
+                'coding_style/yaml_structure',
+                'coding_style/yaml_dynamic',
+                'coding_style/yaml_interface',
+                'coding_style/yaml_translation',
+                'coding_style/defense',
+                'coding_style/docs_style_guide'
             ]
         },
         {


### PR DESCRIPTION
Matches other docs that we've written more recently. Moving has no effect on the
docs themselves, but also made some additional changes:

* linter changes (including removing trailing spaces)
* added links to docassemble topics where in on part where they were mentioned
* corrected some header levels to be sequential