### PR TITLE
Add better links to Legal Tech Class and also do slight reorganization

### DIFF
--- a/docs/customization/customization_overview.md
+++ b/docs/customization/customization_overview.md
@@ -1,9 +1,14 @@
 ---
 id: customization_overview
-title: Customization and theming
-sidebar_label: Customization and theming
+title: Applying a custom theme or brand
+sidebar_label: Applying a custom theme or brand
 slug: /customization/overview
 ---
+
+## Sharing a custom look and feel across multiple Assembly Line interviews
+
+The [ALThemeTemplate](https://github.com/SuffolkLITLab/docassemble-ALThemeTemplate)
+repository is a template for a "brand" package that you can use for your own organization.
 
 ## Visual customization
 

--- a/docs/customizing_interview.md
+++ b/docs/customizing_interview.md
@@ -1,9 +1,35 @@
 ---
 id: customizing_interview
-title: Customizing your interview
-sidebar_label: Customizing your interview
+title: Editing your interview
+sidebar_label: Editing your interview
 slug: /customizing_interview
 ---
+
+## Edit your completed draft interview in the Docassemble playground
+
+While the Weaver is a menu-driven, step-by-step process, you'll make further
+edits in the Playground. In the playground, you can directly edit the
+[YAML](https://suffolklitlab.org/legal-tech-class/docs/yaml) text to:
+
+1. Change the wording of questions
+1. Change the datatype of questions and add show/hide logic
+1. Edit the order screens appear in
+1. Add conditional and branching logic
+1. Add new variables, such as variables calculated by code
+
+Save your work frequently, and don't be intimidated. For the most part,
+many changes can be understood by reading the text and then experimenting.
+
+This pages offers information about making some common, simple edits.
+You may also want to take this time to read through the materials in
+the [Legal Tech Class](https://suffolklitlab.org/legal-tech-class/docs/introduction-to-docassemble)
+about the underlying Docassemble platform and how it works.
+
+## Work towards a readable, usable interview
+
+You should also take this chance to review our guidance about
+[writing good questions](/docs/question_style_overview.md). While you edit
+your interview, work steadily to make it better.
 
 ## Getting the draft into your playground
 

--- a/docs/framework/magic_variables.md
+++ b/docs/framework/magic_variables.md
@@ -29,6 +29,48 @@ import answers from a JSON file that is uploaded to the server. While this
 allows user control over their data and can be especially helpful for tests,
 this feature carries some risk and is disabled by default.
 
+### Use the AssemblyLine interview list replacement
+
+The AssemblyLine framework includes a replacement for Docassemble's "stock"
+list of in-progress interviews. It has the following improvements:
+
+1. It is significantly faster to load
+1. Results are sorted so the most recent interview is on top
+1. It displays answer sets on their own tab
+1. It hides the "tag" feature
+1. It includes a "start new form" button
+
+If the information is available, the replacement interview list feature can also show a percent
+complete for each interview in the list.
+
+If you would like to use the AssemblyLine interview list instead of Docassemble's
+stock list, edit your configuration to add the following line:
+
+```yaml
+session list interview: docassemble.AssemblyLine:data/questions/interview_list.yml
+```
+
+#### Enhance the custom interview list feature
+If you use the custom interview list feature and you would like to have
+all of your interviews:
+
+1. Save a descriptive name to the database, and
+1. Save their progress to the database
+
+So that both a name like "Smith v. Jones" and a progress like "50%" can
+be displayed on the interview list page, add the following entry to the
+global configuration:
+
+```yaml
+assembly line:
+  update session metadata: True
+```
+
+This option is disabled by default as it does add a few database queries
+to each interview page load. The feature is still new, but it looks
+like it does not have a significant performance impact despite the extra
+database queries.
+
 ## Global configuration options
 
 These variables are recommended to be set in a package that all of your

--- a/docs/question_style_overview.md
+++ b/docs/question_style_overview.md
@@ -24,6 +24,24 @@ more general guidance about good legal writing and good writing for forms.
 We have also thought deeply about how to **measure** the burden that completing
 a form places on a user. You might find our section on [form complexity](complexity/complexity.md) helpful to read along with this section.
 
+## There's no substitute for usability testing
+
+While the contents of this guide are expert guidance, gathered from 
+both our own experience and that of experts in usability, there's no 
+real substitute for observing the experiences of real users of your tool.
+
+The Legal Tech Class has a brief primer on conduction your own 
+[usability tests](https://suffolklitlab.org/legal-tech-class/docs/testing/testing#usability-tests).
+Usability testing can be simple, cheap, and easy!
+
+1. Plan to conduct just a few--you'll learn most of what you need after the 
+  third test, and gain almost nothing after a 5th test.
+1. Usability tests involve one user at a time, not a group.  
+1. You can follow a simple script to do a usability test!
+1. Honorariums help. Be ready to pay people for their time.
+
+[Read more](https://suffolklitlab.org/legal-tech-class/docs/testing/testing#usability-tests)
+
 ## Other content resources
 ### Quick reads
 * [Best practice in form design: round up](https://www.effortmark.co.uk/best-practice-forms-design-round/)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,6 +20,16 @@ module.exports = {
         // { to: 'docs/', activeBasePath: 'docs', label: 'Docs', position: 'left', },
         // {to: 'blog', label: 'Blog', position: 'left'},
         {
+          href: 'https://suffolklitlab.org/legal-tech-class/docs/introduction-to-docassemble',
+          label: 'Introduction to Docassemble',
+          position: 'right',
+        },
+        {
+          href: 'https://docassemble.org/docs.html',
+          label: 'Docassemble Documentation',
+          position: 'right',
+        },
+        {
           href: 'https://github.com/SuffolkLITLab/docassemble-AssemblyLine',
           label: 'GitHub',
           position: 'right',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,21 +1,20 @@
 module.exports = {
     someSidebar: [
         'intro',
-        'bootcamp',
-        'getting_started',
         {
             type: 'category',
-            label: 'Assembly Line Process',
+            label: 'Setting up your own Assembly Line team',
             items: [
+                'bootcamp',
+                'getting_started',
                 'assembly_line_steps',
                 'assembly_line_steps_roles',
                 'assembly_line_steps_planning_time',
                 'assembly_line_steps_step_by_step',
+                'customization/customization_overview',
             ],
         },
         'installation',
-        'al_project_architecture',
-        'customization/customization_overview',
         {
             type: 'category',
             label: 'Authoring your interview',
@@ -83,6 +82,7 @@ module.exports = {
             type: 'category',
             label: 'Feature documentation',
             items: [
+                'al_project_architecture',                
                 'framework/framework_overview',
                 'framework/magic_variables',
                 'framework/algeneral',


### PR DESCRIPTION
Bit of a mixed PR. We got some feedback at our grant partners meeting that it wasn't clear what content lives in this repo and which lives in the Legal Tech Class (which is fair--the line is a bit fuzzy).

Mostly, this PR adds links to the Legal Tech Class. I've also rearranged the sidebar a bit to better distinguish between content needed for individual automators and that needed for people trying to set up a new AssemblyLine project for their own state. That second goal is one that nobody has really encountered yet, so content related to it has been made a bit less prominent, and some other pages that were at a top level have been categorized together.