### PR TITLE
Deprecate `user_role`

### DIFF
--- a/docs/framework/magic_variables.md
+++ b/docs/framework/magic_variables.md
@@ -152,8 +152,9 @@ height, like this:
 
 Add this to a CSS file in your `data/static` folder that you then include in
 your interviews directly or via a shared YAML file.
+
 ### Localization and translation variables
-      
+
 * `AL_DEFAULT_COUNTRY`: [ISO 3166](https://en.wikipedia.org/wiki/ISO_3166) 2
   letter code representing the default country of the interview user for address
   questions. E.g., `US` for United States of America, `UK` for United Kingdom of
@@ -272,11 +273,11 @@ code: |
 ### `al_form_type`
 
 `al_form_type` is used to control some dynamic questions to give more specific
-help information and to give some variables, like `user_role`, a smart default.
+help information and to give some variables, like `user_started_case`, a smart default.
 
 Valid values:
 
-- Starts a new court case: `'starts_case'`
+- Starts a new court case: `'starts_case'`. This will set `user_started_case` to `True`.
 - Filed in or responding to an existing court case: `'existing_case'`
 - Part of an appeal of a court case: `'appeal'`
 - Form that is not filed in a court: `'other_form'`
@@ -365,22 +366,24 @@ code: |
 court that the user has chosen to file the case in. This may be used
 in some automatically gathered statistics as well as in e-filing code.
 
-### `user_role`
+### `user_ask_role`
 
-Several questions depend on the value of `user_role` directly to address the
+Several questions depend on the value of `user_ask_role` directly to address the
 `user` correctly as either the party initiating or responding to a case.
 
-`user_role` should be exactly one of "plaintiff" or "defendant". Use "plaintiff"
+`user_ask_role` should be exactly one of "plaintiff" or "defendant". Use "plaintiff"
 when you mean "petitioner", and use "defendant" even if you mean "respondent". This
 is just the internal shorthand for starting or responding to the case.
 
-This is commonly but not always set in a code block.
+The Weaver will set `user_ask_role` directly if it can be, otherwise,
+it will be asked to the user.
 
-### `user_ask_role`
+### `user_role`
 
-`user_ask_role` is used for the same purpose (and will define the value of)
-`user_role`. It can also contain exactly 1 of 2 values: "plaintiff" or "defendant".
-The difference is that `user_ask_role` is expected to be set by asking a question.
+`user_role` is set by set in a code block directly in interviews, or set by [`user_ask_role`](#user_ask_role).
+It serves the same purpose as `user_ask_role`. However to simplify interviews, we suggest you
+use `user_ask_role` instead.
+
 
 ### `user_started_case`
 

--- a/docs/weaver_code_anatomy.md
+++ b/docs/weaver_code_anatomy.md
@@ -133,8 +133,9 @@ id: interview_order_a_258e_motion_for_impoundment
 code: |
   # Set the allowed courts for this interview
   allowed_courts = interview_metadata["a_258e_motion_for_impoundment"]["allowed courts"]
-  nav.set_section('review_a_258e_motion_for_impoundment')
-  user_role = 'plaintiff'
+  nav.set_section("review_a_258e_motion_for_impoundment")
+  user_role ="plaintiff"
+  user_ask_role = "plaintiff"
   one_of_your_custom_questions
   users[0].phone_number
   another_of_your_custom_questions
@@ -148,7 +149,7 @@ code: |
 
 1. `allowed_courts` allows the developer to limit which courts the person filling out the form can pick from, making it easier for them to pick the right court. By default, it's using the same values that are in the [metadata block](#assemblyline-metadata).
 1. `nav.set_section()` comes after `al_intro_screen` and `a_258e_motion_for_impoundment_intro` so that the user can't click to edit their answers before they've actually been asked any questions.
-1. `user_role` tells AssemblyLine which questions to ask about the main party listed on the form. This should be the same as the `typical role`. However, if `typical role` is `unknown`, then the `user_ask_role` variable will be here instead, and will ask the user what role they have in the case.
+1. `user_role` and `user_ask_role` tell AssemblyLine which questions to ask about the main party and opposing parties listed on the form. These should be the same as the `typical role`. However, if `typical role` is `unknown`, then the `user_ask_role` variable will be here instead, and will ask the user what role they have in the case.
 
 Code for your custom questions comes next. All your questions should be triggered in here. You will probably make major edits to the code here, changing the order and adding branching logic.
 


### PR DESCRIPTION
With https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/596 and https://github.com/SuffolkLITLab/docassemble-ALWeaver/pull/698, `user_role` isn't used much anymore. This PR makes the docs consistent on that, refering to `user_ask_role` when necessary, and explictly encouraging people to use `user_ask_role` over `user_role`.