### PR TITLE
Remove "simply" and "simple" from instructions

### DIFF
--- a/docs/assembly_line_steps_planning_time.md
+++ b/docs/assembly_line_steps_planning_time.md
@@ -29,7 +29,7 @@ If you are a completely new Docassemble developer, we recommend getting familiar
 Give yourself 2-3 weeks to become familiar with Docassemble basics.
 
 The Weaver is a guided process, but it may still take a few weeks to familiarize yourself with its options. Start with
-a very simple, already labeled form for your first experience.
+a simple, already labeled form for your first experience.
 
 ## Getting your first prototype
 

--- a/docs/automated_testing.md
+++ b/docs/automated_testing.md
@@ -79,7 +79,7 @@ Feature: I have children
 
 ## First test
 
-You can write a really simple test right away that just makes sure your YAML file runs. Write a `Scenario` for each file you want to test.
+You can write a short test right away that just makes sure your YAML file runs. Write a `Scenario` for each file you want to test.
 
 ```
 Feature: Interviews load

--- a/docs/customizing_interview.md
+++ b/docs/customizing_interview.md
@@ -76,7 +76,7 @@ You will likely start by clicking the "Save and Run" button to try running your
 interview through to the end. Note any awkward wording or changes you want to make.
 
 Use the `id` that is on the top of each screen to find the screen that you want to change.
-Then, simply change the text that you want to change, or change the order of fields.
+Then, change the text that you want to change, or change the order of fields.
 
 ![id: request a guardianship](./assets/playground_id.png)
 
@@ -164,7 +164,7 @@ function `val()` at least once. `val()` is a JavaScript function that returns
 the value of a variable name that is visible on screen. It takes the name of the
 Docassemble variable in quotes as its only parameter.
 
-Here is a simple example of a `js show if` expression:
+Here is a small example of a `js show if` expression:
 
 ```yaml
 ---
@@ -328,13 +328,13 @@ Avoid:
 ```
 
 :::note Tip
-To comment out many lines at once, hold the ALT key and click and drag a line 
+To comment out many lines at once, hold the ALT key and click and drag a line
 with your mouse. If you do it correctly you will see a long blinking cursor.
 Now you can type on multiple lines at once. Type a `#` and a space to comment out the lines
 with the blinking cursor.
 :::
 
-If you want to discard your changes and start over, simply upload the package .ZIP file
+If you want to discard your changes and start over, upload the package .ZIP file
 to your playground again. This will wipe out all of your changes.
 
 Use [GitHub](github.md) regularly to let you restore your work from a point in time.

--- a/docs/doc_vars_reference.md
+++ b/docs/doc_vars_reference.md
@@ -351,7 +351,7 @@ Replace `expense_rent` or `house` with any valid keyword in the example below.
 Docassemble does not work with PDF forms that use the same label for a field
 twice.
 
-To work around this issue, simply annotate the second or third field with two
+To work around this issue, annotate the second or third field with two
 underscores and any digit, like this: `__1`.
 
 Replace `users1_name` with any other valid field name in the example below.

--- a/docs/framework/aldocument.md
+++ b/docs/framework/aldocument.md
@@ -517,7 +517,7 @@ the interview.
 
 ### Using a simple file field
 
-In a Word document, you can simply use a [`datatype:
+In a Word document, you can use a [`datatype:
 file`](https://docassemble.org/docs/fields.html#file) field. Then,
 put the field representing the file upload in your document with ordinary
 `Jinja2` tags.

--- a/docs/framework/algeneral.md
+++ b/docs/framework/algeneral.md
@@ -66,7 +66,7 @@ The `address_fields()` method includes the following optional parameters:
 
 #### ALAddressList {#ALAddressList}
 
-The `ALAddressList` class is simply a collection of `ALAddress`es. It is used to
+The `ALAddressList` class is a collection of `ALAddress`es. It is used to
 allow you to collect multiple addresses in one go and otherwise works exactly
 like the built-in Docassemble [`DAList`
 object](https://docassemble.org/docs/objects.html#DAList).
@@ -195,7 +195,7 @@ to target questions to a specific type of person:
 * `Survivor`
 
 Each class subclasses `ALIndividual` and shares its methods and attributes.
-There are no special attributes or methods of these classes. They are simply
+There are no special attributes or methods of these classes. They are
 provided for you to customize questions.
 
 <!-- Note these are not really useful outside of stock questions

--- a/docs/framework/reserved_keywords.md
+++ b/docs/framework/reserved_keywords.md
@@ -8,7 +8,7 @@ slug: /framework/reserved_keywords
 
 ## What is a "reserved" name?
 
-A reserved variable name is simple a variable name that already has a
+A reserved variable name is a variable name that already has a
 predefined meaning. Using a reserved variable name can lead to unexpected
 results or a hard to understand error in your interview.
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -383,7 +383,7 @@ You can still make your pull request, but GitHub will prohibit merging. There ar
 
 Either way, the most reliable way to deal with this situation is, unfortunately, to redo your changes on top of the new code:
 
-1. Make the pull request as usual, but simply use it as a tool. The changes you made will be highlighted in the [file comparison tab](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-comparing-branches-in-pull-requests).
+1. Make the pull request as usual, and use it as a tool. The changes you made will be highlighted in the [file comparison tab](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-comparing-branches-in-pull-requests).
 1. In docassemble [create a new Project](https://docassemble.org/docs/playground.html#projects) and pull in the other branch (the one you want to merge with).
 1. Using the file comparison as a guide, manually add your changes back.
 1. Make sure functionality affected by your code changes still works the way it should.
@@ -652,7 +652,7 @@ Regular commit messages can also link to or close issues, just like [the commit 
 
 See the GitHub docs on [closing an issue with a PR](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). The issue will only be closed when the PR is merged into your [default branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-branches#about-the-default-branch) (usually the one called 'main'). Example: `Add all financial questions, fix #15`
 
-You can also just create a link to an issue with a PR or commit by simply omitting the closing keywords shown in the GitHub documentation. Just use the pound sign (`#`) and the number of the issue. Example: `Add question about assets, #15`
+You can also just create a link to an issue with a PR or commit by omitting the closing keywords shown in the GitHub documentation. Just use the pound sign (`#`) and the number of the issue. Example: `Add question about assets, #15`
 <!-- 
 **Adding a link to an issue in your commit or PR**
 

--- a/docs/question_style_structure.md
+++ b/docs/question_style_structure.md
@@ -117,7 +117,7 @@ On longer interviews, it may not be enough to use the sections on the left
 to orient the user.
 
 One way to orient the user is to use "signposts". Signposts are screens
-that do not ask any questions but simply tell the user what questions are
+that do not ask any questions, but instead tell the user what questions are
 coming next.
 
 Consider adding signposts:

--- a/docs/weaver_code_anatomy.md
+++ b/docs/weaver_code_anatomy.md
@@ -82,7 +82,7 @@ code: |
 ```
 
 1. `title`, `short title`, and `description` allow your organization's site to show more information about your form and to organize your forms more easily.
-1. `original_form` is simply a link to the original, fillable PDF form that this interview is automating, if it exists.
+1. `original_form` is a link to the original, fillable PDF form that this interview is automating, if it exists.
 1. 🚧 `allowed courts` allows your code to decide which courts to let the user pick from when they need to pick their court, usually used in conjunction with [AL Generic Jurisdiction](https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction).
 1. `categories` is the [LIST taxonomy](https://taxonomy.legal/) code for this interview, which can be used by your organization to organize your interviews.
 1. `attachment block variable` used to be used in the code that sends documents to courts, but now the [ALDocument object block](#aldocument-object-block) is used instead.


### PR DESCRIPTION
The words don't add to their sentences, and in the worst case, they can make new users feel insecure by suggesting that something they don't understand is actually easy to understand.

Was a quick recommendation that I've seen around, and didn't spend long editing it. Thoughts welcome.