### PR TITLE
Add FormFyxer code reference docs to doc site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           repository: SuffolkLITLab/docassemble-AssemblyLine
           path: docassemble-AssemblyLine
+      - uses: actions/checkout@v2
+        with:
+          repository: SuffolkLITLab/FormFyxer
+          path: FormFyxer
       - name: Go to Docs directory
         run: |
           cd docs

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           repository: SuffolkLITLab/docassemble-AssemblyLine
           path: docassemble-AssemblyLine
+      - uses: actions/checkout@v2
+        with:
+          repository: SuffolkLITLab/docassemble-AssemblyLine
+          path: FormFyxer
       - name: Go to Docs directory
         run: |
           cd docs

--- a/docs/reference/formfyxer/lit_explorer.md
+++ b/docs/reference/formfyxer/lit_explorer.md
@@ -1,0 +1,256 @@
+---
+sidebar_label: lit_explorer
+title: formfyxer.lit_explorer
+---
+
+#### recursive\_get\_id
+
+```python
+def recursive_get_id(values_to_unpack: Union[dict, list],
+                     tmpl: Optional[set] = None)
+```
+
+Pull ID values out of the LIST/NSMI results from Spot.
+
+#### spot
+
+```python
+def spot(text: str,
+         lower: float = 0.25,
+         pred: float = 0.5,
+         upper: float = 0.6,
+         verbose: float = 0,
+         token: str = "")
+```
+
+Call the Spot API (https://spot.suffolklitlab.org) to classify the text of a PDF using
+the NSMIv2/LIST taxonomy (https://taxonomy.legal/), but returns only the IDs of issues found in the text.
+
+#### re\_case
+
+```python
+def re_case(text: str) -> str
+```
+
+Capture PascalCase, snake_case and kebab-case terms and add spaces to separate the joined words
+
+#### regex\_norm\_field
+
+```python
+def regex_norm_field(text: str)
+```
+
+Apply some heuristics to a field name to see if we can get it to match AssemblyLine conventions.
+See: https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/document_variables
+
+#### reformat\_field
+
+```python
+def reformat_field(text: str, max_length: int = 30)
+```
+
+Transforms a string of text into a snake_case variable close in length to `max_length` name by
+summarizing the string and stitching the summary together in snake_case.
+h/t https://towardsdatascience.com/nlp-building-a-summariser-68e0c19e3a93
+
+#### norm
+
+```python
+def norm(row)
+```
+
+Normalize a word vector.
+
+#### vectorize
+
+```python
+def vectorize(text: str, normalize: bool = True)
+```
+
+Vectorize a string of text.
+
+#### normalize\_name
+
+```python
+def normalize_name(jur: str, group: str, n: int, per, last_field: str,
+                   this_field: str) -> Tuple[str, float]
+```
+
+Add hard coded conversions maybe by calling a function
+if returns 0 then fail over to ML or other way around poor prob -&gt; check hard-coded.
+Retuns the new name and a confidence value between 0 and 1
+
+#### cluster\_screens
+
+```python
+def cluster_screens(fields: List[str] = [], damping: float = 0.7)
+```
+
+Takes in a list (fields) and returns a suggested screen grouping
+Set damping to value &gt;= 0.5 or &lt; 1 to tune how related screens should be
+
+## InputType Objects
+
+```python
+class InputType(Enum)
+```
+
+Input type maps onto the type of input the PDF author chose for the field. We only
+handle text, checkbox, and signature fields.
+
+#### field\_types\_and\_sizes
+
+```python
+def field_types_and_sizes(
+        fields: Optional[Iterable[FormField]]) -> List[FieldInfo]
+```
+
+Transform the fields provided by get_existing_pdf_fields into a summary format.
+Result will look like:
+[
+{
+&quot;var_name&quot;: var_name,
+&quot;type&quot;: &quot;text | checkbox | signature&quot;,
+&quot;max_length&quot;: n
+}
+]
+
+## AnswerType Objects
+
+```python
+class AnswerType(Enum)
+```
+
+Answer type describes the effort the user answering the form will require.
+&quot;Slot-in&quot; answers are a matter of almost instantaneous recall, e.g., name, address, etc.
+&quot;Gathered&quot; answers require looking around one&#x27;s desk, for e.g., a health insurance number.
+&quot;Third party&quot; answers require picking up the phone to call someone else who is the keeper
+of the information.
+&quot;Created&quot; answers don&#x27;t exist before the user is presented with the question. They may include
+a choice, creating a narrative, or even applying legal reasoning. &quot;Affidavits&quot; are a special
+form of created answers.
+See Jarret and Gaffney, Forms That Work (2008)
+
+#### classify\_field
+
+```python
+def classify_field(field: FieldInfo, new_name: str) -> AnswerType
+```
+
+Apply heuristics to the field&#x27;s original and &quot;normalized&quot; name to classify
+it as either a &quot;slot-in&quot;, &quot;gathered&quot;, &quot;third party&quot; or &quot;created&quot; field type.
+
+#### time\_to\_answer\_field
+
+```python
+def time_to_answer_field(field: FieldInfo,
+                         new_name: str,
+                         cpm: int = 40,
+                         cpm_std_dev: int = 17) -> Callable[[int], np.ndarray]
+```
+
+Apply a heuristic for the time it takes to answer the given field, in minutes.
+It is hand-written for now.
+It will factor in the input type, the answer type (slot in, gathered, third party or created), and the
+amount of input text allowed in the field.
+The return value is a function that can return N samples of how long it will take to answer the field (in minutes)
+
+#### time\_to\_answer\_form
+
+```python
+def time_to_answer_form(processed_fields,
+                        normalized_fields) -> Tuple[float, float]
+```
+
+Provide an estimate of how long it would take an average user to respond to the questions
+on the provided form.
+We use signals such as the field type, name, and space provided for the response to come up with a
+rough estimate, based on whether the field is:
+1. fill in the blank
+2. gathered - e.g., an id number, case number, etc.
+3. third party: need to actually ask someone the information - e.g., income of not the user, anything else?
+4. created:
+a. short created (3 lines or so?)
+b. long created (anything over 3 lines)
+
+#### cleanup\_text
+
+```python
+def cleanup_text(text: str, fields_to_sentences: bool = False) -> str
+```
+
+Apply cleanup routines to text to provide more accurate readability statistics.
+
+#### complete\_with\_command
+
+```python
+def complete_with_command(text,
+                          command,
+                          tokens,
+                          creds: Optional[OpenAiCreds] = None) -> str
+```
+
+Combines some text with a command to send to open ai.
+
+#### needs\_calculations
+
+```python
+def needs_calculations(text: Union[str, Doc]) -> bool
+```
+
+A conservative guess at if a given form needs the filler to make math calculations,
+something that should be avoided. If
+
+#### get\_passive\_sentences
+
+```python
+def get_passive_sentences(
+        text: Union[List, str]) -> List[Tuple[str, List[str]]]
+```
+
+Return a list of tuples, where each tuple represents a
+sentence in which passive voice was detected along with a list of each
+fragment that is phrased in the passive voice. The combination of the two
+can be used in the PDFStats frontend to highlight the passive text in an
+individual sentence.
+
+Text can either be a string or a list of strings.
+If provided a single string, it will be tokenized with NTLK and
+sentences containing fewer than 2 words will be ignored.
+
+#### get\_citations
+
+```python
+def get_citations(text: str, tokenized_sentences: List[str]) -> List[str]
+```
+
+Get citations and some extra surrounding context (the full sentence), if the citation is
+fewer than 5 characters (often eyecite only captures a section symbol
+for state-level short citation formats)
+
+#### parse\_form
+
+```python
+def parse_form(in_file: str,
+               title: Optional[str] = None,
+               jur: Optional[str] = None,
+               cat: Optional[str] = None,
+               normalize: bool = True,
+               spot_token: Optional[str] = None,
+               openai_creds: Optional[OpenAiCreds] = None,
+               rewrite: bool = False,
+               debug: bool = False)
+```
+
+Read in a pdf, pull out basic stats, attempt to normalize its form fields, and re-write the
+in_file with the new fields (if `rewrite=1`). If you pass a spot token, we will guess the
+NSMI code. If you pass openai creds, we will give suggestions for the title and description.
+
+#### form\_complexity
+
+```python
+def form_complexity(stats)
+```
+
+Gets a single number of how hard the form is to complete. Higher is harder.
+

--- a/docs/reference/formfyxer/pdf_wrangling.md
+++ b/docs/reference/formfyxer/pdf_wrangling.md
@@ -1,0 +1,264 @@
+---
+sidebar_label: pdf_wrangling
+title: formfyxer.pdf_wrangling
+---
+
+## FormField Objects
+
+```python
+class FormField()
+```
+
+A data holding class, used to easily specify how a PDF form field should be created.
+
+#### \_\_init\_\_
+
+```python
+def __init__(field_name: str,
+             type_name: Union[FieldType, str],
+             x: int,
+             y: int,
+             font_size: Optional[int] = None,
+             tooltip: str = "",
+             configs: Optional[Dict[str, Any]] = None)
+```
+
+Constructor
+
+**Arguments**:
+
+- `x` - the x position of the lower left corner of the field. Should be in X,Y coordinates,
+  where (0, 0) is the lower left of the page, x goes to the right, and units are in
+  points (1/72th of an inch)
+- `y` - the y position of the lower left corner of the field. Should be in X,Y coordinates,
+  where (0, 0) is the lower left of the page, y goes up, and units are in points
+  (1/72th of an inch)
+- `config` - a dictionary containing any keyword argument to the reportlab field functions,
+  which will vary depending on what type of field this is. See section 4.7 of the
+  [reportlab User Guide](https://www.reportlab.com/docs/reportlab-userguide.pdf)
+- `field_name` - the name of the field, exposed to via most APIs. Not the tooltip, but `users1_name__0`
+
+#### set\_fields
+
+```python
+def set_fields(in_file: Union[str, Path, BinaryIO],
+               out_file: Union[str, Path, BinaryIO],
+               fields_per_page: Iterable[Iterable[FormField]],
+               *,
+               overwrite=False)
+```
+
+Adds fields per page to the in_file PDF, writing the new PDF to out_file.
+
+Example usage:
+```
+set_fields(&#x27;no_fields.pdf&#x27;, &#x27;four_fields_on_second_page.pdf&#x27;,
+  [
+    [],  # nothing on the first page
+    [ # Second page
+      FormField(&#x27;new_field&#x27;, &#x27;text&#x27;, 110, 105, configs={&#x27;width&#x27;: 200, &#x27;height&#x27;: 30}),
+      # Choice needs value to be one of the possible options, and options to be a list of strings or tuples
+      FormField(&#x27;new_choices&#x27;, &#x27;choice&#x27;, 110, 400, configs={&#x27;value&#x27;: &#x27;Option 1&#x27;, &#x27;options&#x27;: [&#x27;Option 1&#x27;, &#x27;Option 2&#x27;]}),
+      # Radios need to have the same name, with different values
+      FormField(&#x27;new_radio1&#x27;, &#x27;radio&#x27;, 110, 600, configs={&#x27;value&#x27;: &#x27;option a&#x27;}),
+      FormField(&#x27;new_radio1&#x27;, &#x27;radio&#x27;, 110, 500, configs={&#x27;value&#x27;: &#x27;option b&#x27;})
+    ]
+  ]
+)
+
+#### rename\_pdf\_fields
+
+```python
+def rename_pdf_fields(in_file: Union[str, Path, BinaryIO],
+                      out_file: Union[str, Path, BinaryIO],
+                      mapping: Mapping[str, str]) -> None
+```
+
+Given a dictionary that maps old to new field names, rename the AcroForm
+field with a matching key to the specified value
+
+#### unlock\_pdf\_in\_place
+
+```python
+def unlock_pdf_in_place(in_file: Union[str, Path, BinaryIO]) -> None
+```
+
+Try using pikePDF to unlock the PDF it it is locked. This won&#x27;t work if it has a non-zero length password.
+
+#### get\_existing\_pdf\_fields
+
+```python
+def get_existing_pdf_fields(
+        in_file: Union[str, Path, BinaryIO, Pdf]) -> List[List[FormField]]
+```
+
+Use PikePDF to get fields from the PDF
+
+#### swap\_pdf\_page
+
+```python
+def swap_pdf_page(*,
+                  source_pdf: Union[str, Path, Pdf],
+                  destination_pdf: Union[str, Path, Pdf],
+                  source_offset: int = 0,
+                  destination_offset: int = 0,
+                  append_fields: bool = False) -> Pdf
+```
+
+(DEPRECATED: use copy_pdf_fields) Copies the AcroForm fields from one PDF to another blank PDF form. Optionally, choose a starting page for both
+the source and destination PDFs. By default, it will remove any existing annotations (which include form fields)
+in the destination PDF. If you wish to append annotations instead, specify `append_fields = True`
+
+#### copy\_pdf\_fields
+
+```python
+def copy_pdf_fields(*,
+                    source_pdf: Union[str, Path, Pdf],
+                    destination_pdf: Union[str, Path, Pdf],
+                    source_offset: int = 0,
+                    destination_offset: int = 0,
+                    append_fields: bool = False) -> Pdf
+```
+
+Copies the AcroForm fields from one PDF to another blank PDF form. Optionally, choose a starting page for both
+the source and destination PDFs. By default, it will remove any existing annotations (which include form fields)
+in the destination PDF. If you wish to append annotations instead, specify `append_fields = True`
+
+#### get\_textboxes\_in\_pdf
+
+```python
+def get_textboxes_in_pdf(in_file: Union[str, Path, BinaryIO],
+                         line_margin=0.02,
+                         char_margin=2.0) -> List[List[Textbox]]
+```
+
+Gets all of the text boxes found by pdfminer in a PDF, as well as their bounding boxes
+
+#### get\_bracket\_chars\_in\_pdf
+
+```python
+def get_bracket_chars_in_pdf(in_file: Union[str, Path, BinaryIO],
+                             line_margin=0.02,
+                             char_margin=0.0) -> List
+```
+
+Gets all of the bracket characters (&#x27;[&#x27; and &#x27;]&#x27;) found by pdfminer in a PDF, as well as their bounding boxes
+TODO: Will eventually be used to find [ ] as checkboxes, but right now we can&#x27;t tell the difference between [ ] and [i].
+This simply gets all of the brackets, and the characters of [hi] in a PDF and [ ] are the exact same distance apart.
+Currently going with just &quot;[hi]&quot; doesn&#x27;t happen, let&#x27;s hope that assumption holds.
+
+#### intersect\_bbox
+
+```python
+def intersect_bbox(bbox_a, bbox_b, vert_dilation=2, horiz_dilation=2) -> bool
+```
+
+bboxes are [left edge, bottom edge, horizontal length, vertical length]
+
+#### intersect\_bboxs
+
+```python
+def intersect_bboxs(bbox_a,
+                    bboxes,
+                    vert_dilation=2,
+                    horiz_dilation=2) -> Iterable[bool]
+```
+
+Returns an iterable of booleans, one of each of the input bboxes, true if it collides with bbox_a
+
+#### contain\_boxes
+
+```python
+def contain_boxes(bbox_a: BoundingBoxF, bbox_b: BoundingBoxF) -> BoundingBoxF
+```
+
+Given two bounding boxes, return a single bounding box that contains both of them.
+
+#### get\_dist\_sq
+
+```python
+def get_dist_sq(point_a: XYPair, point_b: XYPair) -> float
+```
+
+returns the distance squared between two points. Faster than the true euclidean dist
+
+#### get\_dist
+
+```python
+def get_dist(point_a: XYPair, point_b: XYPair) -> float
+```
+
+euclidean (L^2 norm) distance between two points
+
+#### get\_connected\_edges
+
+```python
+def get_connected_edges(point: XYPair, point_list: Sequence)
+```
+
+point list is always ordered clockwise from the bottom left,
+i.e. bottom left, top left, top right, bottom right
+
+#### bbox\_distance
+
+```python
+def bbox_distance(
+    bbox_a: BoundingBoxF, bbox_b: BoundingBoxF
+) -> Tuple[float, Tuple[XYPair, XYPair], Tuple[XYPair, XYPair]]
+```
+
+Gets our specific &quot;distance measure&quot; between two different bounding boxes.
+This distance is roughly the sum of the horizontal and vertical difference in alignment of
+the closest shared field-bounding box edge. We are trying to find which, given a list of text boxes
+around a field, is the most likely to be the actual text label for the PDF field.
+
+bboxes are 4 floats, x, y, width and height
+
+#### get\_possible\_checkboxes
+
+```python
+def get_possible_checkboxes(img: Union[str, cv2.Mat],
+                            find_small=False) -> Union[np.ndarray, List]
+```
+
+Uses boxdetect library to determine if there are checkboxes on an image of a PDF page.
+Assumes the checkbox is square.
+
+find_small: if true, finds smaller checkboxes. Sometimes will &quot;find&quot; a checkbox in letters,
+like O and D, if the font is too small
+
+#### get\_possible\_radios
+
+```python
+def get_possible_radios(img: Union[str, BinaryIO, cv2.Mat])
+```
+
+Even though it&#x27;s called &quot;radios&quot;, it just gets things shaped like circles, not
+doing any semantic analysis yet.
+
+#### get\_possible\_text\_fields
+
+```python
+def get_possible_text_fields(
+        img: Union[str, BinaryIO, cv2.Mat],
+        text_lines: List[Textbox],
+        default_line_height: int = 44) -> List[Tuple[BoundingBox, int]]
+```
+
+Uses openCV to attempt to find places where a PDF could expect an input text field.
+
+Caveats so far: only considers straight, normal horizonal lines that don&#x27;t touch any vertical lines as fields
+Won&#x27;t find field inputs as boxes
+
+default_line_height: the default height (16 pt), in pixels (at 200 dpi), which is 45
+
+#### auto\_add\_fields
+
+```python
+def auto_add_fields(in_pdf_file: Union[str, Path], out_pdf_file: Union[str,
+                                                                       Path])
+```
+
+Uses `get_possible_fields` and `set_fields` to automatically add new fields
+to an input PDF.
+

--- a/docs/reference/sidebar.json
+++ b/docs/reference/sidebar.json
@@ -1,5 +1,13 @@
 {
   "items": [
+    {
+      "items": [
+        "reference/formfyxer/lit_explorer",
+        "reference/formfyxer/pdf_wrangling"
+      ],
+      "label": "formfyxer",
+      "type": "category"
+    },
     "reference/al_courts",
     "reference/al_document",
     "reference/al_general",

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -1,6 +1,6 @@
 loaders:
   - type: python
-    search_path: [../docassemble-AssemblyLine/docassemble/AssemblyLine]
+    search_path: [../docassemble-AssemblyLine/docassemble/AssemblyLine, ../FormFyxer]
 processors:
   - type: filter
     skip_empty_modules: true


### PR DESCRIPTION
In the same way that we do for AssemblyLine code.

Right now the non-code documentation for the FormFyxer is in [it's README.md](https://github.com/SuffolkLITLab/FormFyxer/blob/main/README.md). This isn't bad, but the Readme gets out of date quickly. The better way is to have function documentation next to the function itself.

With this change, the FormFyxer code will have reference documentation on our docs site itself, and we can then simply point from the FormFyxer README to the site to have the most up to date code.

Tried to separate out other problems that our reference docs have in #313; this PR won't be handling those problems, though it does just add more pages with those problems to the site.