### PR TITLE
Add ALToolbox API reference

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           repository: SuffolkLITLab/FormFyxer
           path: FormFyxer
+      - uses: actions/checkout@v2
+        with:
+          repository: SuffolkLITLab/docassemble-ALToolbox
+          path: docassemble-ALToolbox
       - name: Go to Docs directory
         run: |
           cd docs

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           repository: SuffolkLITLab/docassemble-AssemblyLine
           path: FormFyxer
+      - uses: actions/checkout@v2
+        with:
+          repository: SuffolkLITLab/docassemble-ALToolbox
+          path: docassemble-ALToolbox
       - name: Go to Docs directory
         run: |
           cd docs

--- a/docs/reference/ALToolbox/al_income.md
+++ b/docs/reference/ALToolbox/al_income.md
@@ -1,0 +1,894 @@
+---
+sidebar_label: al_income
+title: ALToolbox.al_income
+---
+
+#### times\_per\_year
+
+```python
+def times_per_year(times_per_year_list: List[Tuple[int, str]],
+                   times_per_year: float) -> str
+```
+
+Get the lower-case textual description that matches a time period contained
+in a &quot;times per year&quot; list.
+
+The goal of this function is to allow you to reflect the user&#x27;s selection
+back to them, either on screen or in a document.
+
+In `al_income.yml` there is a default `times_per_year_list`, but the list
+that you use must be passed as a parameter as it&#x27;s common to want to
+customize this for a given financial statement.
+
+For example: if the `times_per_year` is 12, it will return &quot;monthly&quot; from
+the default `times_per_year_list`.
+
+If the times per year does not exist in the given list, it will return a
+literal string like &quot;five times per year&quot;.
+
+Fractional or floating point-based times_per_year are permissible in the
+times_per_year_list, although they are not commonly used. E.g., `.5` would
+represent &quot;every two years&quot;. Items not contained in the list (to provide a
+specific lookup name) will have a string representation that is rounded to
+the nearest whole integer.
+
+#### recent\_years
+
+```python
+def recent_years(past: int = 25,
+                 order: str = "descending",
+                 future: int = 1) -> List[int]
+```
+
+Returns a list of the most recent past years, continuing into the future.
+Defaults to most recent 15 years+1. Useful to populate a combobox of years
+where the most recent ones are most likely. E.g. automobile years or
+birthdate.
+
+Keyword parameters:
+* past {float} The number of past years to list, including the current year.
+The default is 15
+* order {string} &#x27;descending&#x27; or &#x27;ascending&#x27;. Default is `descending`.
+* future (defaults to 1).
+
+## ALPeriodicAmount Objects
+
+```python
+class ALPeriodicAmount(DAObject)
+```
+
+Represents an amount (could be an income or an expense depending on the context)
+that reoccurs some times per year. E.g, to express a weekly period, use 52. The default
+is 1 (a year).
+
+**Attributes**:
+
+  .value {str | float | Decimal} A number representing an amount of money accumulated during
+  the `times_per_year` of this income.
+  .times_per_year {float | Decimal} Represents a number of the annual frequency of
+  the income. E.g. 12 for a monthly income.
+  .source {str} (Optional) The &quot;source&quot; of the income, like a &quot;job&quot; or a &quot;house&quot;.
+  .display_name {str} (Optional) If present, will have a translated string to show the
+  user, as opposed to a raw english string from the program
+
+#### \_\_str\_\_
+
+```python
+def __str__() -> str
+```
+
+Returns the income&#x27;s `.total()` as string, not its object name.
+
+#### total
+
+```python
+def total(times_per_year: float = 1) -> Decimal
+```
+
+Returns the income over the specified times_per_year,
+
+To calculate `.total()`, an ALPeriodicAmount must have a `.times_per_year` and `.value`.
+
+## ALIncome Objects
+
+```python
+class ALIncome(ALPeriodicAmount)
+```
+
+Represents an income which may have an hourly rate or a salary. Hourly rate
+incomes must include hours per period (times per year). Period is some
+denominator of a year. E.g, to express a weekly period, use 52. The default
+is 1 (a year).
+
+**Attributes**:
+
+  .value {str | float | Decimal} A number representing an amount of money accumulated during
+  the `times_per_year` of this income.
+  .times_per_year {float | Decimal} Represents a number of the annual frequency of
+  the income. E.g. 12 for a monthly income.
+  .is_hourly {bool} (Optional) True if the income is hourly.
+  .hours_per_period {float | Decimal} (Optional) If the income is hourly, the number of
+  hours during the annual frequency of this job. E.g. if the annual
+  frequency is 52 (weekly), the hours per week might be 50. That is, 50
+  hours per week. This attribute is required if `.is_hourly` is True.
+  .source {str} (Optional) The &quot;source&quot; of the income, like a &quot;job&quot; or a &quot;house&quot;.
+  .owner {str} (Optional) Full name of the income&#x27;s owner as a single string.
+
+#### total
+
+```python
+def total(times_per_year: float = 1) -> Decimal
+```
+
+Returns the income over the specified times_per_year, taking into account
+hours per period for hourly items. For example, for an hourly income of 10
+an hour, 40 hours a week, `income.total(1)` would be 20,800, the yearly income,
+and `income.total(52)` would be 400, the weekly income.
+
+To calculate `.total()`, an ALIncome must have a `.times_per_year` and `.value`.
+It can also have `.is_hourly` and `.hours_per_period`.
+
+## ALExpense Objects
+
+```python
+class ALExpense(ALPeriodicAmount)
+```
+
+Not much changes from ALPeriodic Amount, just the generic object questions
+
+## ALIncomeList Objects
+
+```python
+class ALIncomeList(DAList)
+```
+
+Represents a filterable DAList of incomes-type items. It can make
+use of these attributes and methods in its items:
+
+.source
+.owner
+.times_per_year
+.value
+.total()
+
+#### sources
+
+```python
+def sources() -> Set[str]
+```
+
+Returns a set of the unique sources in the ALIncomeList.
+
+#### matches
+
+```python
+def matches(source: SourceType,
+            exclude_source: Optional[SourceType] = None) -> "ALIncomeList"
+```
+
+Returns an ALIncomeList consisting only of elements matching the specified
+income source, assisting in filling PDFs with predefined spaces. `source`
+may be a list.
+
+#### total
+
+```python
+def total(times_per_year: float = 1,
+          source: Optional[SourceType] = None,
+          exclude_source: Optional[SourceType] = None,
+          owner: Optional[str] = None) -> Decimal
+```
+
+Returns the total periodic value in the list, gathering the list items
+if necessary. You can optionally filter by `source`. `source` can be a
+string or a list. You can also filter by one `owner`.
+
+To calculate `.total()` correctly, all items must have a `.total()` and
+it should be a positive value. Job-type incomes should automatically
+exclude deductions.
+
+#### move\_checks\_to\_list
+
+```python
+def move_checks_to_list(selected_types: Optional[DADict] = None,
+                        selected_terms: Optional[Mapping] = None)
+```
+
+Gives a &#x27;gather by checklist&#x27; option.
+If no selected_types param is passed, requires that a .selected_types
+attribute be set by a `datatype: checkboxes` fields
+If &quot;other&quot; is in the selected_types, the source will not be set directly
+
+Sets the attribute &quot;moved&quot; to true, doesn&#x27;t set gathered, because this isn&#x27;t
+idempotent, so trying to also gather all info about the checks in the list doesn&#x27;t
+work well.
+
+## ALJob Objects
+
+```python
+class ALJob(ALIncome)
+```
+
+Represents a single job that may be hourly or pay-period based.
+
+The job can have a net and gross income figure, but it does not represent
+individual items like wages, tips or deductions that may appear on a paycheck--the
+user must enter the total amount for &quot;net&quot; and &quot;gross&quot; income for a given period.
+
+Can be stored in an ALJobList.
+
+**Attributes**:
+
+  .value {float | Decimal} A number representing an amount of money accumulated during
+  the `times_per_year` of this income.
+  .times_per_year {float} Represents a number of the annual frequency of
+  the value. E.g. 12 for a monthly value.
+  .is_hourly {bool} (Optional): Whether the gross total should be calculated based on hours
+  worked per week
+  .hours_per_period {float} (Optional) The number of hours during the annual
+  frequency of this job. E.g. if the annual frequency is 52 (weekly), the
+  hours per week might be 50. That is, 50 hours per week.
+  .deduction {float} (Optional) The amount of money deducted from the total value each period.
+  If this job is hourly, deduction is still from each period, not each hour. Used to
+  calculate the net income in `net_income()`.
+  .employer {Individual} (Optional) A docassemble Individual object, employer.address is the address
+  and employer.phone is the phone
+
+#### gross\_total
+
+```python
+def gross_total(times_per_year: float = 1) -> Decimal
+```
+
+Same as ALIncome total. Returns the income over the specified times_per_year,
+representing the `.value` attribute of the item.
+
+`times_per_year` is some denominator of a year. E.g. to express a weekly
+period, use 52. The default is 1 (a year).
+
+#### deductions
+
+```python
+def deductions(times_per_year: float = 1) -> Decimal
+```
+
+Returns the total deductions from someone&#x27;s pay over the specificed times_per_year
+(not per hour if hourly).
+
+`times_per_year` is some denominator of a year. E.g. to express a weekly
+period, use 52. The default is 1 (a year).
+
+#### net\_total
+
+```python
+def net_total(times_per_year: float = 1) -> Decimal
+```
+
+Returns the net income over a time period, found using
+`self.value` and `self.deduction`.
+
+`times_per_year` is some denominator of a year. E.g, to express a weekly
+period, use 52. The default is 1 (a year).
+
+`self.deduction` is the amount deducted from one&#x27;s pay over a period (not
+per hour if hourly).
+
+This will force the gathering of the ALJob&#x27;s `.value` and `.deduction` attributes.
+
+#### employer\_name\_address\_phone
+
+```python
+def employer_name_address_phone() -> str
+```
+
+Returns name, address and phone number of employer as a string. Forces
+gathering the `.employer`, `.employer_address`, and `.employer_phone`
+attributes.
+
+#### normalized\_hours
+
+```python
+def normalized_hours(times_per_year: float = 1) -> float
+```
+
+Returns the normalized number of hours worked in a given times_per_year,
+based on the self.hours_per_period and self.times_per_year attributes.
+
+For example, if the person works 10 hours a week, it will return
+520 when the times_per_year parameter is 1.
+
+`times_per_year` is some denominator of a year. E.g, to express a weekly
+period, use 52. The default is 1 (a year).
+
+This will force the gathering of the attributes `.hours_per_period` and
+`.times_per_year`
+
+## ALJobList Objects
+
+```python
+class ALJobList(ALIncomeList)
+```
+
+Represents a list of ALJobs. Adds the `.gross_total()` and
+`.net_total()` methods to the ALIncomeList class. It&#x27;s a more common
+way of reporting income than ALItemizedJobList.
+
+#### total
+
+```python
+def total(times_per_year: float = 1,
+          source: Optional[SourceType] = None,
+          exclude_source: Optional[SourceType] = None,
+          owner: Optional[str] = None) -> Decimal
+```
+
+Returns the sum of the gross incomes of its ALJobs divided by the time
+times_per_year. You can filter the jobs by `source`. `source` can be a
+string or a list.
+
+`times_per_year` is some denominator of a year. E.g, to express a weekly
+period, use 52. The default is 1 (a year).
+
+#### gross\_total
+
+```python
+def gross_total(times_per_year: float = 1,
+                source: Optional[SourceType] = None,
+                exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the sum of the gross incomes of its ALJobs divided by the time
+times_per_year. You can filter the jobs by `source`. `source` can be a
+string or a list.
+
+`times_per_year` is some denominator of a year. E.g, to express a weekly
+period, use 52. The default is 1 (a year).
+
+#### net\_total
+
+```python
+def net_total(times_per_year: float = 1,
+              source: Optional[SourceType] = None,
+              exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the sum of the net incomes of its ALJobs divided by the time
+times_per_year. You can filter the jobs by `source`. `source` can be a
+string or a list. Leaving out `source` will use all sources.
+
+If the job is hourly, the `net_total()` may not be comparable to the
+`gross_total()`.
+
+`times_per_year` is some denominator of a year. E.g, to express a weekly
+period, use 52. The default is 1 (a year).
+
+#### deductions
+
+```python
+def deductions(times_per_year: float = 1,
+               source: Optional[SourceType] = None,
+               exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the sum of the deductions of its ALJobs divided by the time
+times_per_year. You can filter the jobs by `source`. Leaving out `source`
+will use all sources.
+
+## ALExpenseList Objects
+
+```python
+class ALExpenseList(ALIncomeList)
+```
+
+A list of expenses
+
+* each element has a:
+* value
+* source
+* display name
+
+## ALAsset Objects
+
+```python
+class ALAsset(ALIncome)
+```
+
+An ALAsset represents an asset that has a market value, an optional income
+that the asset earns, and an optional balance which may be helpful if the
+asset represents a financial account rather than a physical asset.
+
+Can be stored in an ALAssetList.
+
+**Attributes**:
+
+  .market_value {float | Decimal} Market value of the asset.
+  .balance {float | Decimal } Current balance of the account, e.g., like
+  the balance in a checking account, but could also represent a loan
+  amount.
+  .value {float | Decimal} (Optional) Represents the income the asset earns
+  for a given `times_per_year`, such as interest earned in a checking
+  account. If not defined, the income will be set to 0, to simplify
+  representing the many common assets that do not earn any income.
+  .times_per_year {float} (Optional) Number of times per year the asset
+  earns the income listed in the `value` attribute.
+  .owner {str} (Optional) Full name of the asset owner as a single string.
+  .source {str} (Optional) The &quot;source&quot; of the asset, like &quot;vase&quot;.
+
+#### total
+
+```python
+def total(times_per_year: float = 1) -> Decimal
+```
+
+Returns the .value attribute divided by the times per year you want to
+calculate. The value defaults to 0.
+
+`times_per_year` is some denominator of a year. E.g, to express a weekly
+period, use 52. The default is 1 (a year).
+
+## ALAssetList Objects
+
+```python
+class ALAssetList(ALIncomeList)
+```
+
+A list of ALAssets. The `total()` of the list will be the total income
+earned, which may not be what you want for a list of assets. To get the
+total value of all assets, use the `market_value()` method.
+
+#### market\_value
+
+```python
+def market_value(source: Optional[SourceType] = None,
+                 exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the total `.market_value` of assets in the list. You can filter
+the assets by `source`. `source` can be a string or a list.
+
+#### balance
+
+```python
+def balance(source: Optional[SourceType] = None,
+            exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the total `.balance` of assets in the list,
+which typically corresponds to the available funds
+in a financial account.
+
+You can filter the assets by `source`. `source` can be a string or a list.
+
+#### owners
+
+```python
+def owners(source: Optional[SourceType] = None,
+           exclude_source: Optional[SourceType] = None) -> Set[str]
+```
+
+Returns a set of the unique owners of the assets.  You can filter the
+assets by `source`. `source` can be a string or a list.
+
+## ALVehicle Objects
+
+```python
+class ALVehicle(ALAsset)
+```
+
+An ALAsset with special attributes that help representing a vehicle.
+
+Vehicles have a .year_make_model() method which facilitates
+listing vehicles on many financial statement forms.
+
+**Attributes**:
+
+  .year {str} The model year of the vehicle, like 2022
+  .make {str} The make of the vehicle, like &quot;Honda&quot;
+  .model {str} The model of the vehicle, like &quot;Accord&quot;
+  .market_value {float | Decimal} Market value of an asset.
+  .balance {float | Decimal} Balance of an asset.
+  .value {float | Decimal} (Optional) Income earned by the vehicle (typically 0)
+  .times_per_year {float} Time frequency over which the `value` is earned
+  .owner {str} Full name of the asset owner as a single string.
+  .source {str} (Optional) The &quot;source&quot; of the asset. Defaults to &quot;vehicle&quot;.
+
+#### year\_make\_model
+
+```python
+def year_make_model() -> str
+```
+
+Returns a string of the format year/make/model of the vehicle. Triggers
+gathering those attributes.
+
+## ALVehicleList Objects
+
+```python
+class ALVehicleList(ALAssetList)
+```
+
+List of ALVehicles. Extends ALAssetList.
+
+## ALSimpleValue Objects
+
+```python
+class ALSimpleValue(DAObject)
+```
+
+Represents a currency value. It&#x27;s meant to be stored in a list. Can be an
+item in an ALSimpleValueList.
+
+**Attributes**:
+
+  .value {str | float } The monetary value of the item.
+  .transaction_type {str} (Optional) Can be &quot;expense&quot;, which will give a
+  negative value to the total of the item.
+  .source {str} (Optional) The &quot;source&quot; of the item, like &quot;vase&quot;.
+
+#### total
+
+```python
+def total() -> Decimal
+```
+
+If desired, to use as a ledger, values can be signed (mixed positive and
+negative). Setting transaction_type = &#x27;expense&#x27; makes the value negative.
+Use min=0 in that case.
+
+If you use signed values, be careful when placing in an ALIncomeList
+object. The `total()` method may return unexpected results in that case.
+
+#### \_\_str\_\_
+
+```python
+def __str__() -> str
+```
+
+Returns the total as a formatted string
+
+## ALSimpleValueList Objects
+
+```python
+class ALSimpleValueList(DAList)
+```
+
+Represents a filterable DAList of ALSimpleValues.
+
+#### sources
+
+```python
+def sources() -> Set
+```
+
+Returns a set of the unique sources of values stored in the list.
+
+#### total
+
+```python
+def total(source: Optional[SourceType] = None,
+          exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the total value in the list, gathering the list items if
+necessary. You can filter the values by `source`. `source` can be a
+string or a list.
+
+## ALItemizedValue Objects
+
+```python
+class ALItemizedValue(DAObject)
+```
+
+An item in an ALItemizedValueDict (a line item like wages, tips or union dues).
+Should be a positive number, even if it will later be subtracted from the
+job&#x27;s net total.
+
+WARNING: This item&#x27;s period-based value can&#x27;t be calculated correctly
+outside of an ALItemizedJob. Its value should only be accessed through the
+filtering methods of the ALItemizedJob that contains it.
+
+**Attributes**:
+
+  .value {float | Decimal} A number representing an amount of money accumulated
+  during the `times_per_year` of this item or this item&#x27;s job.
+  .is_hourly {bool} Whether this particular item is calculated hourly.
+  .times_per_year { float} A denominator of a year representing the annual
+  frequency of the job. E.g. 12 for monthly.
+  .exists {bool} (Optional) Allows an interview author to pre-define some common
+  descriptors, like &quot;wages&quot; or &quot;union dues&quot; without requiring the user to
+  provide a value for each item.
+  
+  If the &quot;.exists&quot; attribute is False or undefined, the item will not be used
+  when calculating totals.
+
+#### income\_fields
+
+```python
+def income_fields(use_exists=True) -> List[Dict[str, Any]]
+```
+
+Returns a YAML structure representing the list of fields for an itemized value,
+to be passed to a `code` attribute of a question&#x27;s fields
+
+#### \_\_str\_\_
+
+```python
+def __str__() -> str
+```
+
+Returns a string of the value of the item with two decimal places.
+
+## ALItemizedValueDict Objects
+
+```python
+class ALItemizedValueDict(DAOrderedDict)
+```
+
+Dictionary that can contain ALItemizedValues (e.g. line items) for an
+ALItemizedJob. E.g., wages, tips and deductions being the most common.
+
+An ALItemizedJob will have two ALItemizedValueDicts, one for income
+and one for deductions.
+
+WARNING: Should only be accessed through an ALItemizedJob. Otherwise
+you may get unexpected results.
+
+#### hook\_after\_gather
+
+```python
+def hook_after_gather() -> None
+```
+
+Update item lists after they&#x27;ve been gathered or edited to remove non-existent
+items. Will still allow the developer to set `auto_gather=False` if they
+want without affecting this functionality.
+See https://docassemble.org/docs/objects.html#DAList.hook_after_gather.
+
+If a developer wants to remove these items _before_ gathering is finished,
+they can use similar code in their question&#x27;s `validation code:`
+
+#### \_\_str\_\_
+
+```python
+def __str__() -> str
+```
+
+Returns a string of the dictionary&#x27;s key/value pairs as two-element lists in a list.
+E.g. &#x27;[[&quot;federal_taxes&quot;, &quot;2500.00&quot;], [&quot;wages&quot;, &quot;15.50&quot;]]&#x27;
+
+## ALItemizedJob Objects
+
+```python
+class ALItemizedJob(DAObject)
+```
+
+An &quot;Itemized&quot; job is a job which allows the user to report very specific,
+granular details about the money that they earn in that job and any
+deductions that they have on their paycheck. This detailed accounting of
+money for each job is required on some financial statements, although in
+many financial statements, just reporting gross and net income is sufficient.
+
+For example, an ALItemizedJob can let the user report:
+- Wages at one hourly rate
+- Overtime at a second hourly rate
+- Tips earned during that time period
+- A fixed salary earned for that pay period
+- Union Dues
+- Insurance
+- Taxes
+
+If the financial statement only requires &quot;gross&quot; and &quot;net&quot; income, the
+ALJobList has a simpler API and may be the preferred way to represent the
+income in code.
+
+**Attributes**:
+
+  .to_add {ALItemizedValueDict} Dict of ALItemizedValues that would be added
+  to a job&#x27;s net total, like wages and tips.
+  .to_subtract {ALItemizedValueDict} Dict of ALItemizedValues that would be
+  subtracted from a net total, like union dues or insurance premiums.
+  .times_per_year {float} A denominator of a year, like 12 for monthly, that
+  represents how frequently the income is earned
+  .is_hourly {bool} (Optional) Whether the value represents a figure that the
+  user earns on an hourly basis, rather than for the full time period
+  .hours_per_period {int} (Optional) If the job is hourly, how many hours the
+  user works per period.
+  .employer {Individual} (Optional) Individual assumed to have a name and,
+  optionally, an address and phone.
+  .source {str} (Optional) The category of this item, like &quot;public service&quot;.
+  Defaults to &quot;job&quot;.
+  
+- `WARNING` - Individual items in `.to_add` and `.to_subtract` should not be used
+  directly. They should only be accessed through the filtering methods of
+  this job.
+  
+  Fulfills these requirements:
+  - A job can be hourly. Its wages will be calculated with that in mind.
+  - Despite an hourly job, some individual items must be calculated using the
+  job&#x27;s whole period.
+  - Some items will have their own periods.
+  - In a list of jobs, a developer may need to access full time and part time
+  jobs separately.
+  - In a list of jobs, a developer may need to sum all items from one source,
+  such as tips or taxes.
+  - The developer needs access to total money coming in, total money going out,
+  and the total of money going in and money coming out.
+  - A user must be able to add their own arbitrary items.
+
+#### total
+
+```python
+def total(times_per_year: float = 1,
+          source: Optional[SourceType] = None,
+          exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Alias for ALItemizedJob.gross_total to integrate with ALIncomeList math.
+
+#### gross\_total
+
+```python
+def gross_total(times_per_year: float = 1,
+                source: Optional[SourceType] = None,
+                exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the sum of positive values (payments) for a given times_per_year.
+You can filter the items by `source`. `source` can be a string or a list.
+If you use sources from deductions, they will be ignored.
+
+**Arguments**:
+
+- `kwarg` - times_per_year {float} (Optional) Number of times per year you
+  want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+- `kwarg` - source {str | [str]} (Optional) Source or list of sources of desired
+  item(s).
+
+#### deduction\_total
+
+```python
+def deduction_total(times_per_year: float = 1,
+                    source: Optional[SourceType] = None,
+                    exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the sum of money going out (normally, deductions like union
+dues) divided by a pay times_per_year as a positive value. You can
+filter the items by `source`. `source` can be a string or a list.
+
+**Arguments**:
+
+- `kwarg` - times_per_year {float} (Optional) Number of times per year you
+  want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+- `kwarg` - source {str | List[str]} (Optional) Source or list of sources of desired
+  item(s).
+
+#### net\_total
+
+```python
+def net_total(times_per_year: float = 1,
+              source: Optional[SourceType] = None,
+              exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the net (gross minus deductions) value of the job divided by
+`times_per_year`. You can filter the items by `source`. `source` can be a
+string or a list. E.g. &quot;full time&quot; or [&quot;full time&quot;, &quot;union dues&quot;]
+
+**Arguments**:
+
+- `kwarg` - times_per_year {float} (Optional) Number of times per year you
+  want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+- `kwarg` - source {str | List[str]} (Optional) Source or list of sources of desired
+  item(s).
+
+#### employer\_name\_address\_phone
+
+```python
+def employer_name_address_phone() -> str
+```
+
+Returns concatenation of employer name and, if they exist, employer
+address and phone number.
+
+#### normalized\_hours
+
+```python
+def normalized_hours(times_per_year: float = 1) -> float
+```
+
+Returns the normalized number of hours worked in a given times_per_year,
+based on the self.hours_per_period and self.times_per_year attributes.
+
+For example, if the person works 10 hours a week, it will return
+520 when the times_per_year parameter is 1.
+
+## ALItemizedJobList Objects
+
+```python
+class ALItemizedJobList(DAList)
+```
+
+Represents a list of ALItemizedJobs that can have both payments and money
+out. This is a less common way of reporting income.
+
+#### sources
+
+```python
+def sources(which_side: Optional[str] = None) -> Set[str]
+```
+
+Returns a set of the unique sources in all of the jobs.
+By default gets from both sides, if which_side is &quot;deductions&quot;, only gets from deductions.
+
+#### total
+
+```python
+def total(times_per_year: float = 1,
+          source: Optional[SourceType] = None,
+          exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Alias for ALItemizedJobList.gross_total to integrate with
+ALIncomeList math.
+
+#### gross\_total
+
+```python
+def gross_total(times_per_year: float = 1,
+                source: Optional[SourceType] = None,
+                exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the sum of the gross incomes of the list&#x27;s jobs divided by the
+times_per_year. You can filter the items by `source`. `source` can be a
+string or a list.
+
+**Arguments**:
+
+- `kwarg` - source {str | [str]} - (Optional) Source or list of sources of
+  desired job items to sum from every itemized job.
+  E.g. [&#x27;tips&#x27;, &#x27;commissions&#x27;]
+- `kwarg` - times_per_year {float} (Optional) Number of times per year you
+  want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+
+#### deduction\_total
+
+```python
+def deduction_total(times_per_year: float = 1,
+                    source: Optional[SourceType] = None,
+                    exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the sum of the deductions of the list&#x27;s jobs divided by the
+times_per_year. You can filter the items by `source`. `source` can be a
+string or a list.
+
+**Arguments**:
+
+- `kwarg` - source {str | [str]} - (Optional) Source or list of sources of
+  desired job items to sum from every itemized job.
+  E.g. [&#x27;taxes&#x27;, &#x27;dues&#x27;]
+- `kwarg` - times_per_year {float} (Optional) Number of times per year you
+  want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+
+#### net\_total
+
+```python
+def net_total(times_per_year: float = 1,
+              source: Optional[SourceType] = None,
+              exclude_source: Optional[SourceType] = None) -> Decimal
+```
+
+Returns the net of the list&#x27;s jobs (money in minus money out) divided by
+the times_per_year. You can filter the items by `source`. `source` can be a
+string or a list.
+
+**Arguments**:
+
+- `kwarg` - source {str | List[str]} - (Optional) Source or list of sources of
+  desired job items to sum from every itemized job.
+  E.g. [&#x27;tips&#x27;, &#x27;taxes&#x27;]
+- `kwarg` - times_per_year {float} (Optional) Number of times per year you
+  want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+

--- a/docs/reference/ALToolbox/business_days.md
+++ b/docs/reference/ALToolbox/business_days.md
@@ -1,0 +1,83 @@
+---
+sidebar_label: business_days
+title: ALToolbox.business_days
+---
+
+#### standard\_holidays
+
+```python
+def standard_holidays(
+        year,
+        country="US",
+        subdiv="MA",
+        add_holidays: Optional[Mapping] = None,
+        remove_holidays: Optional[Iterable[str]] = None
+) -> holidays.HolidayBase
+```
+
+Get all holidays in the specified year, country, and state (or other subdivision).
+Note that this draws on the &quot;holidays&quot; package which may deviate slightly from
+holidays observed by a local court, but should be very close to accurate.
+
+add_holidays should be a dictionary from dates (&quot;12-15&quot;) to the name of the holiday.
+
+Returns a dictionary like-object that you can treat like:
+{
+&quot;2021-01-01&quot;: &quot;New Year&#x27;s Day&quot;,
+...
+&quot;2021-12-25&quot;: &quot;Christmas Day&quot;,
+}
+
+In place of a string, the object that is returned can also be treated as though
+the keys are datetime.date objects.
+
+#### is\_business\_day
+
+```python
+def is_business_day(date: Union[str, DADateTime],
+                    country="US",
+                    subdiv="MA",
+                    add_holidays: Optional[Mapping] = None,
+                    remove_holidays: Optional[Iterable[str]] = None) -> bool
+```
+
+Returns true iff the specified date is a business day (i.e., not a holiday)
+in the specified jurisdiction. Business days are considered to be:
+1. weekdays other than Saturday and Sunday and
+1. days that are not a federal or state-observed holiday
+
+#### get\_next\_business\_day
+
+```python
+def get_next_business_day(
+        start_date: Union[str, DADateTime],
+        wait_n_days=1,
+        country="US",
+        subdiv="MA",
+        add_holidays: Optional[Mapping] = None,
+        remove_holidays: Optional[Iterable[str]] = None) -> DADateTime
+```
+
+Returns the first day AFTER the specified start date that is
+not a federal or state holiday, Saturday or Sunday. Optionally,
+specify the parameter `wait_n_days` to get the first business day after
+at least, e.g., 10 days.
+
+Relies on the Python holidays package, which has fairly good support for
+holidays around the world and in various states and provinces, but local
+court rules may differ.
+
+#### get\_date\_after\_n\_business\_days
+
+```python
+def get_date_after_n_business_days(
+        start_date: Union[str, DADateTime],
+        wait_n_days=1,
+        country="US",
+        subdiv="MA",
+        add_holidays: Optional[Mapping] = None,
+        remove_holidays: Optional[Iterable[str]] = None) -> DADateTime
+```
+
+Returns a time period which contains a minimum of `n` business days.
+

--- a/docs/reference/ALToolbox/copy_button.md
+++ b/docs/reference/ALToolbox/copy_button.md
@@ -1,0 +1,21 @@
+---
+sidebar_label: copy_button
+title: ALToolbox.copy_button
+---
+
+#### copy\_button\_html
+
+```python
+def copy_button_html(text_to_copy: str,
+                     text_before: str = "",
+                     label: str = "Copy",
+                     tooltip_inert_text: str = "Copy to clipboard",
+                     tooltip_copied_text: str = "Copied!",
+                     copy_template_block: bool = False,
+                     scroll_class: str = "",
+                     style_class: str = "",
+                     adjust_height: str = "") -> str
+```
+
+Return the html for a button that will let a user copy the given text
+

--- a/docs/reference/ALToolbox/misc.md
+++ b/docs/reference/ALToolbox/misc.md
@@ -1,0 +1,171 @@
+---
+sidebar_label: misc
+title: ALToolbox.misc
+---
+
+#### thousands
+
+```python
+def thousands(num: Union[float, str, Decimal], show_decimals=False) -> str
+```
+
+Return a whole number formatted with thousands separator.
+Optionally, format with 2 decimal points (for a PDF form with the
+currency symbol already present in the form)
+
+If `trucate`, will call `int(num)`, truncating the decimals instead of
+rounding to the closest int.
+
+#### tel
+
+```python
+def tel(phone_number) -> str
+```
+
+Format a phone number so you can click on it to open in your phone dialer
+
+#### fa\_icon
+
+```python
+def fa_icon(icon: str,
+            color="primary",
+            color_css=None,
+            size="sm",
+            fa_class="fa-solid") -> str
+```
+
+Return HTML for a font-awesome icon of the specified size and color. You can reference
+a CSS variable (such as Bootstrap theme color) or a true CSS color reference, such as &#x27;blue&#x27; or
+&#x27;`DDDDDD`&#x27;. Defaults to Bootstrap theme color &quot;primary&quot;.
+
+Sizes can be &#x27;2xs&#x27;, &#x27;xs&#x27;, &#x27;sm&#x27;, &#x27;md&#x27; (or None), &#x27;lg&#x27;, &#x27;xl&#x27;, &#x27;2xl&#x27;.
+
+#### space
+
+```python
+def space(var_name: str, prefix=" ", suffix="") -> str
+```
+
+If the value as a string is defined, return it prefixed/suffixed. Defaults to prefix
+of a space. Helps build a sentence with less cruft. Equivalent to SPACE function in
+HotDocs.
+
+#### yes\_no\_unknown
+
+```python
+def yes_no_unknown(var_name: str,
+                   condition: Optional[bool],
+                   unknown="Unknown",
+                   placeholder=0)
+```
+
+Return &#x27;unknown&#x27; if the value is None rather than False. Helper for PDF filling with
+yesnomaybe fields
+
+#### number\_to\_letter
+
+```python
+def number_to_letter(n: Optional[int]) -> str
+```
+
+Returns a capital letter representing ordinal position. E.g., 1=A, 2=B, etc. Appends letters
+once you reach 26 in a way compatible with Excel/Google Sheets column naming conventions. 27=AA, 28=AB...
+
+#### collapse\_template
+
+```python
+def collapse_template(template,
+                      classname=None,
+                      closed_icon="caret-right",
+                      open_icon="caret-down")
+```
+
+Insert HTML for a Bootstrap &quot;collapse&quot; div.
+
+Optionally, you can specify a custom icon to override the defaults:
+
+The default icons are &quot;🞂&quot; which displays when the text is collapsed (`closed_icon`) and
+&quot;▼&quot; which displays when the text is open (`open_icon`).
+
+#### tabbed\_templates\_html
+
+```python
+def tabbed_templates_html(tab_group_name: str, *pargs) -> str
+```
+
+Provided a list of templates, create Bootstrap v 4.5 tabs with the `subject` as the tab label.
+
+#### review\_widget
+
+```python
+def review_widget(
+        *,
+        up_action: str,
+        down_action: str,
+        review_action: Optional[str] = None,
+        thumbs_display: str = "Did we help you?",
+        review_display:
+    str = "Thank you for your feedback. Let us know what we could do better",
+        submit_review_button: str = "Add your review",
+        post_review_display: str = "Thank you for your review!") -> str
+```
+
+A widget that allows people to give a quick review (thumbs up and down, with an optional text
+component) in the middle of an interview without triggering a page reload.
+
+If `review_action` is provided, once you press either of the thumbs, a text input screen with
+a submit button appears, and once the text review is submitted (or after the thumbs, if no
+`review_action` was provided), a final &quot;thank you&quot; messsage is displayed.
+
+**Arguments**:
+
+- `up_action` - the variable name of an event to be executed on the server if the
+  thumbs up is pressed
+- `down_action` - the variable name of an event to be executed on the server if the
+  thumbs down is pressed
+- `review_action` - the variable name of an event to be execute on the
+  server when someone submits their text review
+- `thumbs_display` - text displayed to user describing the thumbs
+- `review_display` - text displayed to user describing the text input
+- `submit_review_button` - text on the button to submit their text review
+- `post_review_display` - text displayed to user after review is submitted
+
+**Returns**:
+
+  the HTML string of the widget
+
+#### sum\_if\_defined
+
+```python
+def sum_if_defined(*pargs)
+```
+
+Lets you add up the value of variables that are not in a list
+
+#### add\_records
+
+```python
+def add_records(obj, labels)
+```
+
+List demo interviews in the current package to be run from the landing page
+
+#### output\_checkbox
+
+```python
+def output_checkbox(value_to_check: bool,
+                    checked_value: str = "[X]",
+                    unchecked_value: str = "[  ]")
+```
+
+Generate a conditional checkbox for docx templates
+
+#### nice\_county\_name
+
+```python
+def nice_county_name(address: Address) -> str
+```
+
+If the county name contains the word &quot;County&quot;, which Google Address
+Autocomplete does by default, remove it.
+

--- a/docs/reference/ALToolbox/save_input_data.md
+++ b/docs/reference/ALToolbox/save_input_data.md
@@ -1,0 +1,18 @@
+---
+sidebar_label: save_input_data
+title: ALToolbox.save_input_data
+---
+
+#### save\_input\_data
+
+```python
+def save_input_data(title: str = "",
+                    input_dict: Optional[Dict[str, Any]] = None,
+                    tags: Optional[List[str]] = None) -> None
+```
+
+This function is used by survey type interviews to save input data for data reporting purposes.
+
+The input_dict should a dictionary where each key is a string and each value is a value from a Docassemble interview
+question. Typically that is a string, float, int, or a DADict.
+

--- a/docs/reference/sidebar.json
+++ b/docs/reference/sidebar.json
@@ -2,6 +2,17 @@
   "items": [
     {
       "items": [
+        "reference/ALToolbox/al_income",
+        "reference/ALToolbox/business_days",
+        "reference/ALToolbox/copy_button",
+        "reference/ALToolbox/misc",
+        "reference/ALToolbox/save_input_data"
+      ],
+      "label": "ALToolbox",
+      "type": "category"
+    },
+    {
+      "items": [
         "reference/formfyxer/lit_explorer",
         "reference/formfyxer/pdf_wrangling"
       ],

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -1,6 +1,9 @@
 loaders:
   - type: python
-    search_path: [../docassemble-AssemblyLine/docassemble/AssemblyLine, ../FormFyxer]
+    search_path:
+      - "../docassemble-AssemblyLine/docassemble/AssemblyLine"
+      - "../FormFyxer"
+      - "../docassemble-ALToolbox/docassemble/"
 processors:
   - type: filter
     skip_empty_modules: true


### PR DESCRIPTION
Currently writing GithubFeedbackForm documentation, and realized that some of the review widget functionality I wanted to write would be better to just point to all of the parameters that you could pass in directly, but that API reference didn't exist yet! A quick add.

To consider (for this or future PRs): do we want to add this for all of our supplemental packages? It depends on if we think people would want to directly call the python code in any of the following packages:

* ALDashboard
* InterviewStats
* GithubFeedbackForm (likely)
* EFSPIntegration (likely, though it'll be so big, I'm not sure if it should split off or not)
* ALWeaver