### PR TITLE
Add EFSPIntegration docs to the API reference

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           repository: SuffolkLITLab/docassemble-ALToolbox
           path: docassemble-ALToolbox
+      - uses: actions/checkout@v2
+        with:
+          repository: SuffolkLITLab/docassemble-EFSPIntegration
+          path: docassemble-EFSPIntegration
       - name: Go to Docs directory
         run: |
           cd docs

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           repository: SuffolkLITLab/docassemble-ALToolbox
           path: docassemble-ALToolbox
+      - uses: actions/checkout@v2
+        with:
+          repository: SuffolkLITLab/docassemble-EFSPIntegration
+          path: docassemble-EFSPIntegration
       - name: Go to Docs directory
         run: |
           cd docs

--- a/docs/reference/EFSPIntegration/conversions.md
+++ b/docs/reference/EFSPIntegration/conversions.md
@@ -1,0 +1,111 @@
+---
+sidebar_label: conversions
+title: EFSPIntegration.conversions
+---
+
+Functions that help convert the JSON-ized XML from the proxy server into usable information.
+
+#### choices\_and\_map
+
+```python
+def choices_and_map(codes_list: List,
+                    display: str = None,
+                    backing: str = None) -> Tuple[List[Any], Dict]
+```
+
+Takes the responses from the &#x27;codes&#x27; service and make a DA ready list of choices and a map back
+to the full code object
+
+#### pretty\_display
+
+```python
+def pretty_display(data, tab_depth=0, skip_xml=True, item_name=None) -> str
+```
+
+Given an arbitrarily nested JSON structure, print it nicely.
+Recursive, for subsequent calls `tab_depth` increases.
+
+#### debug\_display
+
+```python
+def debug_display(resp: ApiResponse) -> str
+```
+
+Returns a string with either the error of the response,
+or it&#x27;s data run through pretty_display
+
+#### tyler\_daterep\_to\_datetime
+
+```python
+def tyler_daterep_to_datetime(tyler_daterep: Mapping) -> DADateTime
+```
+
+Takes an jsonized-XML object of &quot;{http://niem.gov/niem/niem-core/2.0}ActivityDate,
+returns the datetime it repsents.
+
+#### tyler\_timestamp\_to\_datetime
+
+```python
+def tyler_timestamp_to_datetime(timestamp_ms: int) -> DADateTime
+```
+
+Given a timestamp in milliseconds from epoch (in UTC), make a datetime from it
+
+#### validate\_tyler\_regex
+
+```python
+def validate_tyler_regex(data_field: Mapping) -> Callable
+```
+
+Return a function that validates a given input with the provided regex,
+suitable for use with Docassemble&#x27;s `validate:` question modifier
+
+#### parse\_service\_contacts
+
+```python
+def parse_service_contacts(service_list)
+```
+
+We&#x27;ll take both Tyler service contact lists and Niem service contact lists.
+Tyler&#x27;s are just `{&quot;firstName&quot;: &quot;Bob&quot;, &quot;middleName&quot;: &quot;P&quot;, ..., &quot;serviceContactId&quot;: &quot;abcrunh-13...&quot;
+Niem&#x27;s are more complicated
+
+#### fetch\_case\_info
+
+```python
+def fetch_case_info(proxy_conn: ProxyConnection,
+                    new_case: DAObject,
+                    roles: dict = None)
+```
+
+Fills in these attributes with the full case details:
+* attorneys
+* party_to_attorneys
+* case_details_worked
+* case_details
+* case_type
+* title
+* date
+* participants
+
+#### filter\_payment\_accounts
+
+```python
+def filter_payment_accounts(account_list, allowable_card_types) -> List
+```
+
+Gets a list of all payment accounts and filters them by if the card is
+accepted at a particular court
+
+#### get\_tyler\_roles
+
+```python
+def get_tyler_roles(proxy_conn: ProxyConnection,
+                    login_data: Mapping) -> Tuple[bool, bool]
+```
+
+Gets whether or not the user of this interview is a Tyler Admin, and a &#x27;global&#x27; admin.
+The global admin means that they are allowed to change specific Global payment methods,
+and can be listed under the &#x27;global server admins&#x27; section of the &#x27;efile proxy&#x27; settings in the
+DAConfig
+

--- a/docs/reference/EFSPIntegration/efm_client.md
+++ b/docs/reference/EFSPIntegration/efm_client.md
@@ -1,0 +1,75 @@
+---
+sidebar_label: efm_client
+title: EFSPIntegration.efm_client
+---
+
+## ProxyConnection Objects
+
+```python
+class ProxyConnection(EfspConnection)
+```
+
+#### \_\_init\_\_
+
+```python
+def __init__(*,
+             url: str = None,
+             api_key: str = None,
+             credentials_code_block: str = "tyler_login",
+             default_jurisdiction: str = None)
+```
+
+Params:
+url (str)
+api_key (str)
+credentials_code_block (str)
+default_jurisdiction (str)
+
+#### authenticate\_user
+
+```python
+def authenticate_user(tyler_email: str = None,
+                      tyler_password: str = None,
+                      jeffnet_key: str = None,
+                      *,
+                      jurisdiction: str = None) -> ApiResponse
+```
+
+Params:
+tyler_email (str)
+tyler_password (str)
+jeffnet_key (str)
+
+#### register\_user
+
+```python
+def register_user(person: Union[Individual, dict],
+                  registration_type: str,
+                  *,
+                  password: str = None,
+                  firm_name_or_id: str = None) -> ApiResponse
+```
+
+registration_type needs to be INDIVIDUAL, FIRM_ADMINISTRATOR, or FIRM_ADMIN_NEW_MEMBER.
+If registration_type is INDIVIDUAL or FIRM_ADMINISTRATOR, you need a password.
+If it&#x27;s FIRM_ADMINISTRATOR or FIRM_ADMIN_NEW_MEMBER, you need a firm_name_or_id
+
+#### get\_service\_types
+
+```python
+def get_service_types(
+        court_id: str,
+        court_bundle: Union[ALDocumentBundle, dict] = None) -> ApiResponse
+```
+
+Checks the court info: if it has conditional service types, call a special API with all filing info so far to get service types
+
+#### serialize\_person
+
+```python
+def serialize_person(person: Union[Person, Individual]) -> Dict
+```
+
+Converts a Docassemble Person or Individual into a dictionary suitable for
+json.dumps and in format expected by Tyler-specific endpoints on the EFSPProxy
+

--- a/docs/reference/EFSPIntegration/interview_logic.md
+++ b/docs/reference/EFSPIntegration/interview_logic.md
@@ -1,0 +1,82 @@
+---
+sidebar_label: interview_logic
+title: EFSPIntegration.interview_logic
+---
+
+A group of methods that were code blocks in various parts of the EFSP
+package, but for better python tooling support, were moved here.
+
+#### num\_case\_choices
+
+```python
+def num_case_choices() -> int
+```
+
+The number of cases that someone should have to choose between if there are too many.
+Mostly to limit the amount of up-front waiting someone will have to do.
+
+#### search\_case\_by\_name
+
+```python
+def search_case_by_name(*,
+                        proxy_conn,
+                        var_name: str = None,
+                        court_id: str,
+                        somebody,
+                        filter_fn: Callable[[Any], bool],
+                        roles=None) -> Tuple[bool, DAList]
+```
+
+Searches for cases by party name. If there are more than 10 cases found, we don&#x27;t
+add all of the detailed information about the case, just for the first few cases
+
+#### shift\_case\_select\_window
+
+```python
+def shift_case_select_window(proxy_conn,
+                             found_cases: DAList,
+                             *,
+                             direction: str,
+                             start_idx: int,
+                             end_idx: int,
+                             roles: dict = None) -> Tuple[int, int]
+```
+
+Specifically used in case_search.yml, with an action to only fetch a detailed information
+for a few cases at a time
+
+#### get\_full\_court\_info
+
+```python
+def get_full_court_info(proxy_conn, court_id: str) -> Dict
+```
+
+Gets all of the information about the court from the id
+
+#### get\_max\_allowed\_sizes
+
+```python
+def get_max_allowed_sizes(proxy_conn,
+                          court_id: str) -> Optional[Tuple[int, int]]
+```
+
+Returns attachment max size, then message max size
+
+#### filter\_codes
+
+```python
+def filter_codes(options: Iterable, filters: Iterable,
+                 default: str) -> Tuple[List[Any], Optional[str]]
+```
+
+Given a list of filter functions from most specific to least specific,
+(if true, use that code), filters a total list of codes
+
+#### get\_available\_efile\_courts
+
+```python
+def get_available_efile_courts(proxy_conn) -> list
+```
+
+Gets the list of efilable courts, if it can
+

--- a/docs/reference/EFSPIntegration/py_efsp_client.md
+++ b/docs/reference/EFSPIntegration/py_efsp_client.md
@@ -1,0 +1,106 @@
+---
+sidebar_label: py_efsp_client
+title: EFSPIntegration.py_efsp_client
+---
+
+## EfspConnection Objects
+
+```python
+class EfspConnection()
+```
+
+#### \_\_init\_\_
+
+```python
+def __init__(*, url: str, api_key: str, default_jurisdiction: str = None)
+```
+
+Params:
+url (str)
+api_key (str)
+default_jurisdiction (str)
+
+#### authenticate\_user
+
+```python
+def authenticate_user(*,
+                      tyler_email: Optional[str] = None,
+                      tyler_password: Optional[str] = None,
+                      jeffnet_key: Optional[str] = None,
+                      jurisdiction: str = None) -> ApiResponse
+```
+
+Params:
+tyler_email (str)
+tyler_password (str)
+jeffnet_key (str)
+
+#### register\_user
+
+```python
+def register_user(person: dict,
+                  registration_type: str,
+                  *,
+                  password: str = None,
+                  firm_name_or_id: str = None) -> ApiResponse
+```
+
+registration_type needs to be INDIVIDUAL, FIRM_ADMINISTRATOR, or FIRM_ADMIN_NEW_MEMBER.
+If registration_type is INDIVIDUAL or FIRM_ADMINISTRATOR, you need a password.
+If it&#x27;s FIRM_ADMINISTRATOR or FIRM_ADMIN_NEW_MEMBER, you need a firm_name_or_id
+
+#### get\_password\_rules
+
+```python
+def get_password_rules() -> ApiResponse
+```
+
+Password rules are stored in the global court, id 1.
+
+#### get\_notification\_options
+
+```python
+def get_notification_options() -> ApiResponse
+```
+
+AKA NotificationPreferencesList
+
+#### update\_firm
+
+```python
+def update_firm(firm: dict) -> ApiResponse
+```
+
+firm should have the below keys:
+* firstName, middleName, lastName if it&#x27;s a person
+* firmName if it&#x27;s a business
+* address (a dict), with keys addressLine1 addressLine2, city, state, zipCode, country
+* phoneNumber
+* email
+
+#### get\_service\_types
+
+```python
+def get_service_types(court_id: str, all_vars: dict = None) -> ApiResponse
+```
+
+Checks the court info: if it has conditional service types, call a special API with all filing info so far to get service types
+
+#### get\_cases\_raw
+
+```python
+def get_cases_raw(court_id: str,
+                  *,
+                  person_name: dict = None,
+                  business_name: str = None,
+                  docket_number: str = None) -> ApiResponse
+```
+
+Finds existing cases at a particular court. Only one of person_name, business_name, or docket_number should be
+provided at a time.
+Params:
+court_id (str)
+person_name (dict)
+buisness_name (str)
+docket_number (str)
+

--- a/docs/reference/EFSPIntegration/test/test_conversions.md
+++ b/docs/reference/EFSPIntegration/test/test_conversions.md
@@ -1,0 +1,71 @@
+---
+sidebar_label: test_conversions
+title: EFSPIntegration.test.test_conversions
+---
+
+## TestConversions Objects
+
+```python
+class TestConversions(unittest.TestCase)
+```
+
+Tests conversions.py on the &quot;vars.json&quot; file
+
+#### test\_parse\_case\_info
+
+```python
+def test_parse_case_info()
+```
+
+Makes sure that participants of the case are parsed fully, needed
+
+## TestNoneResp Objects
+
+```python
+class TestNoneResp(unittest.TestCase)
+```
+
+Tests with none responses conversions.py on the &quot;vars.json&quot; file
+
+#### test\_none
+
+```python
+def test_none()
+```
+
+Makes sure that participants of the case are parsed fully, needed
+
+## TestCourtSwitching Objects
+
+```python
+class TestCourtSwitching(unittest.TestCase)
+```
+
+Tests that if we search a case in a grouped court (say peoria) and
+get back a court from a sub court (peariacr), that the
+court_id from the found case reflects the sub court.
+
+This is necessary, as filings can&#x27;t be accepted to the grouped court.
+
+#### test\_switched\_court
+
+```python
+def test_switched_court()
+```
+
+Makes sure that participants of the case are parsed fully, needed
+
+## TestConversionIgnoreAttorneys Objects
+
+```python
+class TestConversionIgnoreAttorneys(unittest.TestCase)
+```
+
+#### test\_ignore\_attorneys
+
+```python
+def test_ignore_attorneys()
+```
+
+Attorneys are just stuck in the middle with normal case participants. You can&#x27;t attach service contacts to them, so
+

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -4,6 +4,7 @@ loaders:
       - "../docassemble-AssemblyLine/docassemble/AssemblyLine"
       - "../FormFyxer"
       - "../docassemble-ALToolbox/docassemble/"
+      - "../docassemble-EFSPIntegration/docassemble"
 processors:
   - type: filter
     skip_empty_modules: true


### PR DESCRIPTION
[Currently trying to improve the state of the in-code docs for EFSPIntegration](https://github.com/SuffolkLITLab/docassemble-EFSPIntegration/pull/190), but getting this in now makes it simpler to update them later, and to check and link specific lines when writing E-filing documentation.