### PR TITLE
How to advertise a branding package to the Weaver

### DIFF
--- a/docs/bootcamp.md
+++ b/docs/bootcamp.md
@@ -79,7 +79,7 @@ additional questions.
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/VAzXYEacN78" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 * [Using Github in Docassemble](github.md)
-* Customizing basic branding with the [ALGenericJurisdiction](https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction) package.
+* Customizing basic branding with the [ALThemeTemplate](https://github.com/SuffolkLITLab/docassemble-ALThemeTemplate) package.
     * Logo
     * Intro screen
     * Pushing changes to Github
@@ -89,7 +89,7 @@ additional questions.
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/-YtGtVI79dY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 * Here's the [video on setting up your own docassemble server](https://www.youtube.com/watch?v=JXdOCLMFPHc) 
-* [docassemble-ALGenericJurisdiction](https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction) package
+* [docassemble-ALThemeTemplate](https://github.com/SuffolkLITLab/docassemble-ALThemeTemplate) package
 * Introduction to the docassemble.Income class
 * Working with tables and repeated data
 * How to install the Assembly Line packages on your Docassemble server
@@ -110,4 +110,4 @@ Basic runtime | [docassemble.AssemblyLine](https://pypi.org/project/docassemble.
 Massachusetts-specific runtime code | [docassemble.MassAccess](https://pypi.org/project/docassemble.MassAccess/) | https://github.com/SuffolkLITLab/docassemble-MassAccess, https://github.com/SuffolkLITLab/docassemble-ALMassachusetts (must install separately if you install from Github)
 Optional "toolbox"/helper functions | [docassemble.ALToolbox](https://pypi.org/project/docassemble.ALToolbox/) | https://github.com/SuffolkLITLab/docassemble-ALToolbox
 Income gathering functionality | [docassemble.income](https://pypi.org/project/docassemble.income/) | https://github.com/GBLS/docassemble-income
-Customizable starting point for your jurisdiction | * | https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction
+Customizable starting point for your jurisdiction | * | https://github.com/SuffolkLITLab/docassemble-ALThemeTemplate

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,25 +84,60 @@ Next, edit the YAML files to fit your own organization's needs. You may also cho
 add a custom CSS theme.
 
 Now, create a new package from the [Playground packages menu](https://docassemble.org/docs/playground.html#packages).
-Select the files that you customized and push them to your own Github repository.
 Give the package a meaningful name, like LouisianaSharedBranding.
+Select the files that you customized and push them to your own Github repository.
 
 :::info Copy, do not fork
 It is important to copy and create a new package. Do not
-fork the ALGenericJurisdiction package as Docassemble makes it
+fork the ALThemeTemplate package as Docassemble makes it
 challenging to rename a package.
 :::
+
+### Using your ALThemeTemplate with the ALWeaver
+
+If you plan on using the [ALWeaver](weaver_overview.md) to create your
+interviews, you will want to include your branding package in your
+weaved interviews. You can do this by adding 2 files to your branding
+package:
+
+1. [In your modules folder](https://docassemble.org/docs/playground.html#modules), create a file named `advertise_weaver.py` and add the following contents:
+
+    ```python
+    # pre-load
+    import os
+    from docassemble.ALWeaver.custom_values import advertise_capabilities
+
+    if not os.environ.get('ISUNITTEST'):
+        advertise_capabilities(__name__, minimum_version="1.5")
+    ```
+
+2. [In your sources folder](https://docassemble.org/docs/playground.html#sources), create a file named `configuration_capabilities.yml` (needs to be spelled the same), and add the following contents, customizing it to your branding package:
+
+    ```yaml
+    package name: My Package
+    organization_choices:
+      - description: MyPackage
+        dependency: "docassemble.MyPackage @ https://github.com/MyOrg/docassemble-MyPackage/archive/main.zip"
+        include_name: "docassemble.MyPackage:my_package.yml"
+        state: TX
+        country: US
+        default: false
+    ```
+
+    You should replace `MyOrg` and `MyPackage` with the name of your GitHub organization and
+    the name you gave your custom branding package. You should also change `my_package.yml`
+    to be the name of your main YAML file in your branding package.
 
 ## Docker-level server configuration changes we recommend
 
 ### Increase nginx timeouts to 5 minutes
 
-Sometimes, long-running Docassemble processes can "timeout." The default 
+Sometimes, long-running Docassemble processes can "timeout." The default
 experience in Docassemble is to show the server's built-in error page,
 which can be confusing for your end user.
 
 We recommend that you increase the nginx timeout for uwsgi from 60 seconds
-(default) to 5 minutes to reduce the frequency that users run into this 
+(default) to 5 minutes to reduce the frequency that users run into this
 ugly error screen.
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -151,7 +151,7 @@ server and then entering the docker container.
 
 Install a text editor and open the nginx configuration file as follows:
 
-```
+```bash
 apt update
 apt install nano
 nano /etc/nginx/nginx.conf
@@ -165,7 +165,7 @@ Type CTRL+O, Enter, and then CTRL+X to save and exit the configuration file.
 
 Type the following commands to restart the nginx process:
 
-```
+```bash
 supervisorctl restart nginx
 ```
 
@@ -189,20 +189,20 @@ First:
 
 Install a text editor:
 
-```
+```bash
 apt update
 apt install nano
 ```
 
 Create a directory to store your custom configuration files:
 
-```
+```bash
 mkdir /usr/share/nginx/html/errors
 ```
 
 Open a new nano editor:
 
-```
+```bash
 nano /usr/share/nginx/html/errors/custom_504.html
 ```
 
@@ -214,7 +214,7 @@ Type CTRL+O, Enter, and then CTRL+X to save and close the editor.
 
 Edit the `nginx` configuration file to point to your new custom error page:
 
-```
+```bash
 nano /etc/nginx/nginx.conf
 ```
 
@@ -225,6 +225,6 @@ Type CTRL+O, Enter, and then CTRL+X to save and close the editor.
 
 Restart the nginx process:
 
-```
+```bash
 supervisorctl restart nginx
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,8 +80,7 @@ them for your own jurisdiction or organization.
 
 To use this package, [pull it into your own Docassemble playground](https://docassemble.org/docs/playground.html#packages).
 
-Next, edit the YAML files to fit your own organization's needs. You may also choose to
-add a custom CSS theme.
+Next, [follow our guide](customization/customization_overview.md) to edit the YAML files and add a custom CSS theme to fit your own organization's needs.
 
 Now, create a new package from the [Playground packages menu](https://docassemble.org/docs/playground.html#packages).
 Give the package a meaningful name, like LouisianaSharedBranding.
@@ -111,7 +110,7 @@ package:
         advertise_capabilities(__name__, minimum_version="1.5")
     ```
 
-2. [In your sources folder](https://docassemble.org/docs/playground.html#sources), create a file named `configuration_capabilities.yml` (needs to be spelled the same), and add the following contents, customizing it to your branding package:
+2. [In your sources folder](https://docassemble.org/docs/playground.html#sources), create a file named `configuration_capabilities.yml` (needs to have that exact spelling), and add the following contents, customizing it to your branding package:
 
     ```yaml
     package name: My Package

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ Installing the Assembly Line covers the following basic steps:
 1. Install the docassemble.ALDashboard package
 2. Run the installation script
 3. Customize and install the
-   [ALGenericJurisdiction](https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction/)
+   [ALThemeTemplate](https://github.com/SuffolkLITLab/docassemble-ALThemeTemplate/)
    package with branding and question wording to match your needs.
 4. Use the Weaver tool to automate your labeled PDF or DOCX forms.
 
@@ -72,9 +72,9 @@ If you do not know the answer, you can return and manually edit your
 configuration later.
 
 
-## Customize the ALGenericJurisdiction repository
+## Customize the ALThemeTemplate repository
 
-[ALGenericJurisdiction](https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction/)
+[ALThemeTemplate](https://github.com/SuffolkLITLab/docassemble-ALThemeTemplate/)
 is a docassemble package that includes an example of how to modify questions and customize
 them for your own jurisdiction or organization.
 

--- a/docs/weaver_code_anatomy.md
+++ b/docs/weaver_code_anatomy.md
@@ -83,11 +83,11 @@ code: |
 
 1. `title`, `short title`, and `description` allow your organization's site to show more information about your form and to organize your forms more easily.
 1. `original_form` is a link to the original, fillable PDF form that this interview is automating, if it exists.
-1. 🚧 `allowed courts` allows your code to decide which courts to let the user pick from when they need to pick their court, usually used in conjunction with [AL Generic Jurisdiction](https://github.com/SuffolkLITLab/docassemble-ALGenericJurisdiction).
+1. 🚧 `allowed courts` allows your code to decide which courts to let the user pick from when they need to pick their court, usually used in conjunction with [ALThemeTemplate](https://github.com/SuffolkLITLab/docassemble-ALThemeTemplate).
 1. `categories` is the [LIST taxonomy](https://taxonomy.legal/) code for this interview, which can be used by your organization to organize your interviews.
 1. `attachment block variable` used to be used in the code that sends documents to courts, but now the [ALDocument object block](#aldocument-object-block) is used instead.
 1. `logic block variable` should also no longer be used.
-1. `typical role`: controls which questions the user gets asked about themselves and other parties. 
+1. `typical role`: controls which questions the user gets asked about themselves and other parties.
 
 ## Main intro page
 Adds this text to the organization's intro page that appears at the beginning of every interview. This lets your user know right away that they have gotten to the right (or wrong) form. Note that this can (and should) be a more direct and detailed call to action, e.g. ("File a \_\_\_\_" or "Ask the court for \_\_\_\_"), rather than a simple short title, like the short title in the [metadata block](#metadata).

--- a/docs/weaver_overview.md
+++ b/docs/weaver_overview.md
@@ -13,6 +13,7 @@ After your document is fully [labeled](doc_vars_reference.md), the next step is
 to automate a draft in the [Document Assembly Line
 Weaver](https://apps-dev.suffolklitlab.org/start/ALWeaver/assembly_line?new_session=1)
 (ALWeaver).
+
 ## Philosophy
 
 The Assembly Line Weaver is a tool that helps you create a draft of a guided
@@ -89,7 +90,7 @@ a folder on your PC.
 
 Before downloading the package, turn off that behavior:
 
-1. open Safari 
+1. open Safari
 1. click Preferences
 1. under the General tab, uncheck the option **Open 'safe' files after downloading**
 :::


### PR DESCRIPTION
Includes a quick description of the two files that are needed to advertise a branding package to the weaver. Also says how to add a dependency from github, which addresses https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/748.