### PR TITLE
Update action versions, to avoid deprecations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,22 +16,22 @@ jobs:
         with:
           python-version: '3.9'
       - run: pip install docspec_python==2.0.2 pydoc-markdown==4.6.4
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: docs
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: SuffolkLITLab/docassemble-AssemblyLine
           path: docassemble-AssemblyLine
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: SuffolkLITLab/FormFyxer
           path: FormFyxer
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: SuffolkLITLab/docassemble-ALToolbox
           path: docassemble-ALToolbox
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: SuffolkLITLab/docassemble-EFSPIntegration
           path: docassemble-EFSPIntegration
@@ -39,7 +39,7 @@ jobs:
         run: |
           cd docs
           pydoc-markdown
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: npm

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -16,22 +16,22 @@ jobs:
         with:
           python-version: '3.9'
       - run: pip install docspec_python==2.0.2 pydoc-markdown==4.6.4
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: docs
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: SuffolkLITLab/docassemble-AssemblyLine
           path: docassemble-AssemblyLine
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: SuffolkLITLab/docassemble-AssemblyLine
           path: FormFyxer
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: SuffolkLITLab/docassemble-ALToolbox
           path: docassemble-ALToolbox
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: SuffolkLITLab/docassemble-EFSPIntegration
           path: docassemble-EFSPIntegration
@@ -39,7 +39,7 @@ jobs:
         run: |
           cd docs
           pydoc-markdown
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: npm


### PR DESCRIPTION
setup-node@v3, and checkout@v3