### PR TITLE
Use longer but reliable docker exec

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -146,8 +146,7 @@ server and then entering the docker container.
 
 
 1. SSH to the server running Docker.
-1. Type `docker exec -ti [TAB] /bin/bash` (literally tap the 'tab' key at the
-   indicated point) to get an interactive prompt inside your docker container.
+1. Type `docker exec -ti $(docker ps --filter "ancestor=jhpyle/docassemble" --format {{.ID}}) /bin/bash`
 
 Install a text editor and open the nginx configuration file as follows:
 
@@ -184,8 +183,7 @@ past the error string.
 First:
 
 1. SSH to the server running Docker.
-1. Type `docker exec -ti [TAB] /bin/bash` (literally tap the 'tab' key at the
-   indicated point) to get an interactive prompt inside your docker container.
+1. Type `docker exec -ti $(docker ps --filter "ancestor=jhpyle/docassemble" --format {{.ID}}) /bin/bash`
 
 Install a text editor:
 


### PR DESCRIPTION
Tab doesn't work on all SSH clients (talked to someone on docassemble who's tab-complete didn't do anything). This is a bit longer, but will reliably find the only docassemble image running and get it's name. It should be easy to copy paste.