### PR TITLE
Add monitoring to the sidebar

### DIFF
--- a/docs/efiling/efiling_monitoring.md
+++ b/docs/efiling/efiling_monitoring.md
@@ -1,5 +1,5 @@
 ---
-id: operations
+id: monitoring
 title: |
   Monitoring your e-filing operations
 sidebar_label: Monitoring

--- a/sidebars.js
+++ b/sidebars.js
@@ -125,6 +125,7 @@ module.exports = {
                 'efiling/overview',
                 'efiling/efiling_through_docassemble',
                 'efiling/efiling_case_search',
+                'efiling/monitoring',
             ]
         },
         {


### PR DESCRIPTION
I wrote a quick post on [efiling monitoring](https://github.com/SuffolkLITLab/docassemble-AssemblyLine-documentation/commit/fe0cd5ce4351eae2f38caea1e40c158a8b118176) that should be in the efiling sidebar. Will merge when deploy test passes. 