### PR TITLE
Minor cleanup

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,14 +9,15 @@ module.exports = {
   organizationName: 'SuffolkLITLab', // the GitHub org name.
   projectName: 'docassemble-AssemblyLine-documentation', // the repo name.
   themeConfig: {
-    announcementBar: {
-      id: 'lit_con',
-      content:
-        'Suffolk\'s annual 🔥LIT Conference is on April 8th, 2024! <a target="_blank" rel="noopener noreferrer" href="https://suffolklitlab.org/litcon/">Register now!🔥</a>',
-      backgroundColor: '#fafbfc',
-      textColor: '#091E42',
-      isCloseable: false,
-    },
+    // Keeping for the next LIT Con
+    // announcementBar: {
+    //   id: 'lit_con',
+    //   content:
+    //     'Suffolk\'s annual 🔥LIT Conference is on April 8th, 2024! <a target="_blank" rel="noopener noreferrer" href="https://suffolklitlab.org/litcon/">Register now!🔥</a>',
+    //   backgroundColor: '#fafbfc',
+    //   textColor: '#091E42',
+    //   isCloseable: false,
+    // },
     navbar: {
       title: 'The Document Assembly Line',
       logo: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -88,6 +88,10 @@ module.exports = {
           {
             from: '/docs/automated_integrated_testing',
             to: '/docs/alkiln'
+          },
+          {
+            from: ['/docs/','/docs'],
+            to: '/docs/intro'
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "@docusaurus/plugin-google-gtag": "^3.2.1",
     "@docusaurus/plugin-ideal-image": "^3.2.1",
     "@docusaurus/preset-classic": "^3.2.1",
-    "prism-react-renderer": "^2.1.0",
     "@easyops-cn/docusaurus-search-local": "^0.40.1",
     "@mdx-js/react": "^3.0",
     "clsx": "^1.1.1",
+    "prism-react-renderer": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Fix #417 - turn of LIT Con banner. Intentionally leaving commented out so we don't have to look up how to do it again next year
Fix #418  - redirect /docs