### PR TITLE
Close #413, improve link accessibility

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,6 +27,12 @@
   --ifm-footer-padding-vertical: 15px;
 }
 
+article a {
+  text-decoration: underline;
+  text-decoration-thickness: 0.04em;
+  text-underline-offset: 0.3em;
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgb(72, 77, 91);
   display: block;


### PR DESCRIPTION
Here is a picture of an inactive and a hovered link [for articles]:

<img width="479" alt="link_a11y" src="https://github.com/SuffolkLITLab/docassemble-AssemblyLine-documentation/assets/52798256/22ff778c-93f2-4ce7-baf2-f0fb29d94a51">

Closes #413