### PR TITLE
Add the development roadmap page

### DIFF
--- a/docs/get_started/development_roadmap.md
+++ b/docs/get_started/development_roadmap.md
@@ -1,0 +1,50 @@
+---
+id: development_roadmap
+title: Development Roadmap for the Document Assembly Line
+sidebar_label: Development Roadmap
+slug: /get_started/development_roadmap
+---
+
+The Document Assembly Line is under continuous development. Our goal with this roadmap is to share our plans and priorities for the Document Assembly Line with the community.
+
+## Current priorities
+
+### Grant-funded deliverables
+
+In partnership with Legal Services Vermont, funded by a Technology Initiative Grant from the Legal Services Corporation, the LIT Lab is working on the following:
+
+* Managing Docassemble hosting for at least three jurisdictions, including Vermont, by January 2025
+* Creating a flexible, general-purpose e-filing tool that allows e-filing documents prepared outside of Docassemble interviews, by September 2025
+* Expanding e-filing beyond Massachusetts and Illinois to new jurisdictions, including Vermont, by September 2025
+* Supporting our existing e-filing code and staying current with third-party changes. Planned updates include:
+  * ECF 5 compliance
+  * Making it possible to separate e-filing configuration code from Docassemble interview code
+
+### Additional priorities
+
+* Creating an ongoing process for shaping this development roadmap with input from the community, funding partners, etc.
+* Updating this documentation website to better serve Document Assembly Line users and the project's needs
+* Ongoing outreach to courts and legal aid organizations
+
+## Long-term goals
+
+Our ambitious, long-term goals for the Document Assembly Line are:
+
+* Establish a national document assembly and e-filing infrastructure for courts and legal-aid organizations
+* Foster a community of courts and legal aid organizations building access-to-justice tools using the Document Assembly Line
+
+## Releases
+
+Versions and release notes can be found in the Document Assembly Line GitHub repositories:
+
+* [AssemblyLine](https://github.com/SuffolkLITLab/docassemble-AssemblyLine/releases)
+* [courtformsonline.org](https://github.com/SuffolkLITLab/courtformsonline.org/pulls?q=is%3Apr) (no formal releases)
+* [ALWeaver](https://github.com/SuffolkLITLab/docassemble-ALWeaver/releases)
+* [ALToolbox](https://github.com/SuffolkLITLab/docassemble-ALToolbox/releases)
+* [ALRecipes](https://github.com/SuffolkLITLab/docassemble-ALRecipes/pulls?q=is%3Apr) (no formal releases)
+* [PovertyScale](https://github.com/SuffolkLITLab/docassemble-PovertyScale/releases)
+* [GitHubFeedbackForm](https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm/releases)
+* [ALDashboard](https://github.com/SuffolkLITLab/docassemble-ALDashboard/releases)
+* [InterviewStats](https://github.com/SuffolkLITLab/docassemble-InterviewStats/releases)
+* [EFSPIntegration](https://github.com/SuffolkLITLab/docassemble-EFSPIntegration/releases)
+* [EFileProxyServer](https://github.com/SuffolkLITLab/EfileProxyServer/releases)

--- a/sidebars.js
+++ b/sidebars.js
@@ -16,6 +16,7 @@ module.exports = {
             collapsed: false,
         },
         'get_started/resources',
+        'get_started/development_roadmap',
         'contributors',
         {
             type: 'category',
@@ -23,7 +24,7 @@ module.exports = {
             items: [
                 'archive/bootcamp',
             ],
-        },
+        }
     ],
     docs: [
         'overview',


### PR DESCRIPTION
This adds a preliminary document roadmap page to the Document Assembly Line website to help us show potential partners our current commitments and priorities.