### PR TITLE
Adds an underline to current section in the table of contents

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,7 +27,8 @@
   --ifm-footer-padding-vertical: 15px;
 }
 
-article a {
+article a,
+.table-of-contents a.table-of-contents__link--active {
   text-decoration: underline;
   text-decoration-thickness: 0.04em;
   text-underline-offset: 0.3em;
@@ -132,12 +133,6 @@ article .markdown p img {
   html[class*="docs-doc-id-alkiln"] .table-of-contents li:has(> a > code) {
     line-height: 1.5em;
   }
-}
-
-/* Demo what more accessible menu selection can look like */
-html[class*="docs-doc-id-alkiln"] a.table-of-contents__link--active {
-  text-decoration: underline;
-  text-underline-offset: .4em;
 }
 
 html[class*="docs-doc-id-alkiln"] *:not(h1),


### PR DESCRIPTION
Currently in the table of contents for a page the current section is highlighted with the link color, but it's really hard to tell. This PR adds an underline so it is easier to tell the difference. (@plocket tried this in the ALKiln pages to start with, and I think it is worth implementing site-wide.)

Closes #408