### PR TITLE
Fixed broken links in documentation

### DIFF
--- a/docs/components/ALToolbox/misc.md
+++ b/docs/components/ALToolbox/misc.md
@@ -28,7 +28,7 @@ you more control over the icon that is inserted.
 
 - `icon` - a string representing a fontawesome icon. The icon needs to be in the
   [free library](https://fontawesome.com/search?o=r&amp;m=free).
-- `color` - can be any [Bootstrap color variable](https://getbootstrap.com/docs/4.0/utilities/colors).
+- `color` - can be any [Bootstrap color variable](https://getbootstrap.com/docs/5.0/utilities/colors/).
   For example: `primary`, `secondary`, `warning`
 - `color_css` - allows you to use a CSS code to represent the color, e.g., `blue`, or ``fff`` for black
 - `size` - used to control the [fontawesome size](https://fontawesome.com/v6.0/docs/web/style/size)

--- a/docs/components/ALToolbox/misc.md
+++ b/docs/components/ALToolbox/misc.md
@@ -28,7 +28,7 @@ you more control over the icon that is inserted.
 
 - `icon` - a string representing a fontawesome icon. The icon needs to be in the
   [free library](https://fontawesome.com/search?o=r&amp;m=free).
-- `color` - can be any [Bootstrap color variable](https://getbootstrapc.mo/docs/4.0/utilities/colors).
+- `color` - can be any [Bootstrap color variable](https://getbootstrap.com/docs/4.0/utilities/colors).
   For example: `primary`, `secondary`, `warning`
 - `color_css` - allows you to use a CSS code to represent the color, e.g., `blue`, or ``fff`` for black
 - `size` - used to control the [fontawesome size](https://fontawesome.com/v6.0/docs/web/style/size)

--- a/docs/components/FormFyxer/lit_explorer.md
+++ b/docs/components/FormFyxer/lit_explorer.md
@@ -25,7 +25,7 @@ See: https://assemblyline.suffolklitlab.org/docs/document_variables
 
 Transforms a string of text into a snake_case variable close in length to `max_length` name by
 summarizing the string and stitching the summary together in snake_case.
-h/t https://towardsdatascience.com/nlp-building-a-summariser-68e0c19e3a93
+h/t https://medium.com/data-science/nlp-building-a-summariser-68e0c19e3a93
 
 #### norm
 

--- a/docs/components/RateMyPDF/ratemypdf_overview.md
+++ b/docs/components/RateMyPDF/ratemypdf_overview.md
@@ -173,12 +173,12 @@ to identify and validate the features the RateMyPDF score measures.
 1. John P Sabatini. 2002. Efficiency in Word Reading of Adults: Ability Group Comparisons. Scientific Studies of Reading 6, 3 (July 2002), 267–298. DOI:https://doi.org/10.1207/S1532799XSSR0603_4
 1. Mirjam Seckler, Silvia Heinz, Javier A Bargas-Avila, Klaus Opwis, and Alexandre N Tuch. 2014. Designing Usable Web Forms – Empirical Evaluation of Web Form Improvement Guidelines. (2014), 10.
 1. Quinten Steenhuis and David Colarusso. 2021. Digital Curb Cuts: Towards an Open Forms Ecosystem. Akron Law Review 54, 4 (2021), 2.
-1. Survey Monkey. 2008. Smart Survey Design. Survey Monkey. Retrieved December 7, 2021 from https://s3.amazonaws.com/SurveyMonkeyFiles/SmartSurvey.pdf
+1. Survey Monkey. 2008. Smart Survey Design. Survey Monkey. Retrieved December 7, 2021 from https://irp-cdn.multiscreensite.com/89b37107/files/uploaded/SmartSurvey.pdf
 1. Susanne Trauzettel-Klosinski, Klaus Dietz, and the IReST Study Group. 2012. Standardized Assessment of Reading Performance: The New International Reading Speed Texts IReST. Investigative Ophthalmology & Visual Science 53, 9 (August 2012), 5452–5461. DOI:https://doi.org/10.1167/iovs.11-8284
 1. Washington Law Help. 2022. How to File Petition for Order of Protection. Retrieved February 6, 2023 from https://www.washingtonlawhelp.org/files/C9D2EA3F-0350-D9AF-ACAE-BF37E9BC9FFA/attachments/9100D6C9-D107-4B15-87B3-A898F12B6FD8/3701en_how-to-file-petition-for-order-of-protection.pdf
 1. Antoinette Welsh. 2013. Effects of Trauma Induced Stress on Attention, Executive Functioning, Processing Speed, and Resilience in Urban Children. Seton Hall University Dissertations and Theses (ETDs) (December 2013). Retrieved from https://scholarship.shu.edu/dissertations/1907
 1. Jenny Ziviani and John Elkins. 1984. An Evaluation of Handwriting Performance. Educational Review 36, 3 (November 1984), 249–261. DOI:https://doi.org/10.1080/0013191840360304
-1. (2015). Paperwork Reduction Act (44 U.S.C. 3501 et seq.). Digital.gov. Retrieved February 2, 2023 from https://digital.gov/resources/paperwork-reduction-act-44-u-s-c-3501-et-seq/
+1. (2015). Paperwork Reduction Act (44 U.S.C. 3501 et seq.). Digital.gov. Retrieved February 2, 2023 from https://web.archive.org/web/20250124035641/https://digital.gov/resources/paperwork-reduction-act-44-u-s-c-3501-et-seq/
 1. (2023). Textstat. Retrieved February 7, 2023 from https://github.com/textstat/textstat
 1. Field labels to use in template files | The Document Assembly Line Project. Retrieved February 3, 2023 from https://assemblyline.suffolklitlab.org/docs/label_variables
 1. How to estimate burden | A Guide to the Paperwork Reduction Act. Retrieved November 9, 2022 from https://pra.digital.gov/burden/estimation/

--- a/docs/components/formfyxer/lit_explorer.md
+++ b/docs/components/formfyxer/lit_explorer.md
@@ -19,13 +19,13 @@ Capture PascalCase, snake_case and kebab-case terms and add spaces to separate t
 #### regex\_norm\_field
 
 Apply some heuristics to a field name to see if we can get it to match AssemblyLine conventions.
-See: https://assemblyline.suffolklitlab.org/docs/document_variables
+See: https://assemblyline.suffolklitlab.org/docs/authoring/label_variables#fields-labels-and-variables
 
 #### reformat\_field
 
 Transforms a string of text into a snake_case variable close in length to `max_length` name by
 summarizing the string and stitching the summary together in snake_case.
-h/t https://towardsdatascience.com/nlp-building-a-summariser-68e0c19e3a93
+h/t https://medium.com/data-science/nlp-building-a-summariser-68e0c19e3a93
 
 #### norm
 

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -53,7 +53,7 @@ The LIT Lab continues to develop and maintain the Document Assembly Line with he
 * Henry Strum [LinkedIn](https://www.linkedin.com/in/henry-sturm/)
 * Jason Swadel
 * Nicholas Taltos [LinkedIn](https://www.linkedin.com/in/nicholas-taltos-17aa07179/)
-* Vincent Tamburino [LinkedIn](http://www.linkedin.com/in/vincenttamburino)
+* Vincent Tamburino [LinkedIn](https://www.linkedin.com/in/vincenttamburino)
 * Philip Titcomb [LinkedIn](https://www.linkedin.com/in/philip-titcomb/)
 * Sinéad Vaughan [LinkedIn](https://www.linkedin.com/in/sin%C3%A9ad-vaughan-she-her-963788140/)
 * Katharine Walton [LinkedIn](https://www.linkedin.com/in/katharine-walton/)
@@ -63,7 +63,7 @@ The LIT Lab continues to develop and maintain the Document Assembly Line with he
 ### Organizations
 
 * [Suffolk University Law School](https://www.suffolk.edu/law)
-* [Docassemble](https://docassemble.org/docassemble)
+* [Docassemble](https://docassemble.org/)
 * [The Massachusetts Access to Justice Commission](http://www.massa2j.org/a2j/)
 * [Greater Boston Legal Services](https://www.gbls.org/)
 * [Northeast Legal Aid](https://www.northeastlegalaid.org/)

--- a/docs/get_started/intro.md
+++ b/docs/get_started/intro.md
@@ -92,7 +92,7 @@ All code generated as part of this project is available for free [on GitHub](htt
   rapidly generating interviews from marked-up court form PDF and DOCX templates.
 * [ALToolbox](https://github.com/SuffolkLITLab/docassemble-ALToolbox) contains functions and components that might benefit Docassemble developers whether or not they choose not to install the full Document Assembly Line toolbox.
 * [ALRecipes](https://github.com/SuffolkLITLab/docassemble-ALRecipes) examples and snippets that use Assembly Line features or demonstrate best practices. Can be included directly in the Docassemble Playground to supplement the list of Playground examples.
-* [PovertyScale](https://github.com/SuffolkLITLab/docassemble-PovertyScale) which contains a Python library, Docassemble code, static JSON and a REST server for determining income qualification based on the [United States Federal Poverty Scale](https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines), updated on an annual basis.
+* [PovertyScale](https://github.com/SuffolkLITLab/docassemble-PovertyScale) which contains a Python library, Docassemble code, static JSON and a REST server for determining income qualification based on the [United States Federal Poverty Scale](https://web.archive.org/web/20250528044709/http://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines), updated on an annual basis.
 * [GithubFeedbackForm](https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm) helps Docassemble authors collect feedback from users and generate GitHub issues.
 
 ### Docassemble server tools

--- a/docs/style_guide/question_library/addresses.md
+++ b/docs/style_guide/question_library/addresses.md
@@ -362,8 +362,8 @@ Your default address question should be more standardized.
 
 ### Collecting international addresses
 
-* https://www.uxmatters.com/mt/archives/2008/06/international-address-fields-in-web-forms.php
-* https://ux.shopify.com/designing-address-forms-for-everyone-everywhere-f481f6baf513
+* [International Address Fields in Web Forms](https://www.uxmatters.com/mt/archives/2008/06/international-address-fields-in-web-forms.php)
+* [Designing Address Forms for Everyone, Everywhere (Shopify)](https://medium.com/shopify-ux/designing-address-forms-for-everyone-everywhere-f481f6baf513)
 
 ### Collecting address of an unhoused person
 

--- a/docs/style_guide/question_style_overview.md
+++ b/docs/style_guide/question_style_overview.md
@@ -44,16 +44,15 @@ Usability testing can be simple, cheap, and easy!
 
 ## Other content resources
 ### Quick reads
-* [Best practice in form design: round up](https://www.effortmark.co.uk/best-practice-forms-design-round/)
+* [Best practice in form design](https://www.effortmark.co.uk/forms/)
 * How to write [good legal stuff](https://www.law.indiana.edu/instruction/tanford/web/reference/how2writegood.pdf)
-* Readable [Info Sheet](https://www.masslegalservices.org/system/files/library/Create%20a%20Readable%20Info%20Sheet%20in%206%20Steps.pdf)
 * Make it Readable [cheat sheet](https://cheatography.com/stevem/cheat-sheets/make-it-readable/)
 * En rules or em dashes ([google search](https://www.google.com/search?client=safari&rls=en&q=en+rules+or+em+dashes&ie=UTF-8&oe=UTF-8) for this)
-* Mass Legal Services [page](https://www.masslegalservices.org/content/making-legal-information-readable-more-plain-language) (Assembly Line team member Caroline edited most of this content)
+* [Mass Legal Services page](https://web.archive.org/web/20230321113402/https://www.masslegalservices.org/content/making-legal-information-readable-more-plain-language) (Assembly Line team member Caroline edited most of this content)
 * [Gerunds and Participles](https://www.geist.com/writers/writers-toolbox/gerunds-and-participles-avoid-ing-words/): Avoiding -ING words
 
 ### Comprehensive style guides
-* [UK.gov](http://uk.gov/) style guide - [online](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges)
+* [Gov.uk](https://gov.uk/) style guide - [online](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges)
 * [How to write good questions for forms (NHS)](https://service-manual.nhs.uk/content/how-to-write-good-questions-for-forms)
 * MailChimp [style guide](https://styleguide.mailchimp.com/word-list/)
 

--- a/docs/style_guide/question_style_validation.md
+++ b/docs/style_guide/question_style_validation.md
@@ -48,7 +48,7 @@ Avoid validation when:
 ## Further reading
 * [UK.gov guidance on writing error messages](https://design-system.service.gov.uk/components/error-message/#be-clear-and-concise)
 * [UK's NHS guidance on writing error messages](https://service-manual.nhs.uk/design-system/components/error-message)
-* https://uxplanet.org/how-to-write-good-error-messages-858e4551cd4
+* https://uxplanet.org/how-to-write-a-perfect-error-message-da1ca65a8f36
 
 ## "Soft" validation: how to use warnings
 

--- a/docs/style_guide/style_guide_readability.md
+++ b/docs/style_guide/style_guide_readability.md
@@ -44,7 +44,7 @@ Below is a shortened version of the list. Whenever it is possible, replace the w
 | provide | give |
 | assist | help |
 
-It's a good idea to draw most words from the list of [the most common 2000 words](https://www.talkenglish.com/vocabulary/top-2000-vocabulary.aspx) in the English language. A [vocabulary profiler](http://www4.caes.hku.hk/vocabulary/profile.htm) can help you check
+It's a good idea to draw most words from the list of [the most common 2000 words](https://www.talkenglish.com/vocabulary/top-2000-vocabulary.aspx) in the English language. A [vocabulary profiler](https://ngslprofiler.com) can help you check
 to see if you are using uncommon words.
 
 For a fun option, the [UpGoer5](https://splasho.com/upgoer5/latest.php) text editor
@@ -164,12 +164,11 @@ File a motion if you want the judge to order something else.
 
 ## Other content resources
 * How to write [good legal stuff](https://www.law.indiana.edu/instruction/tanford/web/reference/how2writegood.pdf)
-* Readable [Info Sheet](https://www.masslegalservices.org/system/files/library/Create%20a%20Readable%20Info%20Sheet%20in%206%20Steps.pdf)
 * Make it Readable [cheat sheet](https://cheatography.com/stevem/cheat-sheets/make-it-readable/)
-* [UK.gov](http://uk.gov/) style guide - [online](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges)
+* [Gov.uk](https://gov.uk/) style guide - [online](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges)
 * En rules or em dashes ([google search](https://www.google.com/search?client=safari&rls=en&q=en+rules+or+em+dashes&ie=UTF-8&oe=UTF-8) for this)
-* Mass Legal Services [page](https://www.masslegalservices.org/content/making-legal-information-readable-more-plain-language) w/ info Caroline wrote
-* MailChimp [style guide](https://styleguide.mailchimp.com/word-list/)
+* [Mass Legal Services page](https://web.archive.org/web/20230321113402/https://www.masslegalservices.org/content/making-legal-information-readable-more-plain-language) w/ info Caroline wrote
+* [MailChimp style guide](https://styleguide.mailchimp.com/word-list/)
 * [Gerunds and Participles](https://www.geist.com/writers/writers-toolbox/gerunds-and-participles-avoid-ing-words/): Avoiding -ING words
 * [LSC-funded readability materials and course](https://sites.google.com/a/lawny.org/plain-language-library/)
 * [Plain Language Guide](https://bit.ly/plainlanguageguide), National


### PR DESCRIPTION
Corrected links that were broken (mostly 404's, some 410's), either by finding the new link through a quick Google search (usually for medium blogs that have moved) or with a web archive link (for more important resources, like HHS's poverty guidelines).

Had to remove links that didn't have a clear replacement (a Mass Legal Services pdf that wasn't moved elsewhere on the side).

## To reproduce

Found all of the broken links by running [linkinator](https://github.com/JustinBeckwith/linkinator) like this:

```bash
linkinator https://assemblyline.suffolklitlab.org -r --skip https://github.com/.* --skip https://www.linkedin.com/.* --skip https://docs.github.com/.* --timeout 10000
```

As a result, didn't check if any LinkedIn or GitHub links were broken (can't do that automatically, will have to do it manually).

Also had to ignore doi.org URLs, and then had to manually check all of the ones that broke, sometimes 403s were just stopping robots from scraping, but work fine through the browser normally.