### PR TITLE
A bit clearer instructions on when to consider switching the template format up

### DIFF
--- a/docs/authoring/docx_templates.md
+++ b/docs/authoring/docx_templates.md
@@ -6,11 +6,11 @@ slug: docx
 ---
 
 :::tip
-Consider whether to use a PDF template instead.
+If strict layout and matching the original page count are important, consider whether to use a PDF template instead.
 
 **Reasons to use DOCX:**
 
-* DOCX documents will grow or shrink to accomodate as much or as little information as the user provides
+* DOCX documents will grow or shrink to accommodate as much or as little information as the user provides
 * DOCX documents allow you to use lists and repeated groups naturally and with little extra effort after labeling the first item
 * DOCX documents allow you to easily make whole sections of a document contingent
 * DOCX documents work well with linear content that is read by scanning down the page, not across
@@ -19,6 +19,7 @@ Consider whether to use a PDF template instead.
 
 * DOCX documents do not work as well for content formatted in columns or that require precise layout
 * DOCX document content may flow unexpectedly if it is longer than expected
+
 :::
 
 DOCX templates can be edited in any editor that is able to edit DOCX files, including:

--- a/docs/authoring/pdf_templates.md
+++ b/docs/authoring/pdf_templates.md
@@ -6,11 +6,11 @@ slug: pdfs
 ---
 
 :::tip
-Consider whether to use a DOCX template instead.
+If strict layout is not important, consider whether to use a DOCX template instead.
 
 **Reasons to use PDF:**
 
-* PDF files may be the best choice if you are automating an approved court form that already exists as a PDF
+* PDF files are usually the best choice if you are automating an approved court form that already exists as a PDF
 * PDF files are good for heavily formatted content that includes columns and multiple fields on a single line
 
 **Reasons to avoid PDF:**


### PR DESCRIPTION
In class, noticed the students took the 'info' box a bit too literally, especially switching from PDF court form to a DOCX mockup of the form. Softening it here a bit.