### PR TITLE
Update renamed repo slugs and Pages links

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,7 @@ Bootstrap, build, and test the repository:
   git clone https://github.com/SuffolkLITLab/FormFyxer.git  
   git clone https://github.com/SuffolkLITLab/docassemble-ALToolbox.git
   git clone https://github.com/SuffolkLITLab/docassemble-EFSPIntegration.git
-  cd docassemble-AssemblyLine-documentation # return to repo root
+  cd AssemblyLine-docs # return to repo root
   ```
 - Generate Python API documentation: `pydoc-markdown` -- takes 2 seconds
 - Fix FormFyxer case sensitivity: `rm -rf docs/components/formfyxer` (if the directory exists)

--- a/docs/admin_guide_docassemble/combining-interviews.md
+++ b/docs/admin_guide_docassemble/combining-interviews.md
@@ -39,4 +39,4 @@ Example:
 ## Read more
 
 1. https://docassemble.org/docs/logic.html#multiple%20interviews
-1. [Naming your modular interview files](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/coding_style_guide/yaml#use-clear-filenames-for-modular-interview-files)
+1. [Naming your modular interview files](https://assemblyline.suffolklitlab.org/docs/coding_style_guide/yaml#use-clear-filenames-for-modular-interview-files)

--- a/docs/admin_guide_docassemble/rebuild-lightsail-instance.md
+++ b/docs/admin_guide_docassemble/rebuild-lightsail-instance.md
@@ -255,7 +255,7 @@ To exit the log, hit CTRL-C.
 ### Final steps
 
 Once the server is running, it is recommended to increase timeout period of nginx. This
-needs to be done inside docker container. Follow [these instructions](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/installation#increase-nginx-timeouts-to-5-minutes).
+needs to be done inside docker container. Follow [these instructions](https://assemblyline.suffolklitlab.org/docs/installation#increase-nginx-timeouts-to-5-minutes).
 
 If you want to receive email alerts when the new AWS Lightsail instance is working hard,
 set up AWS Lightsail alerts - CPU utilization. A threshold of over 60% CPU utilization 2

--- a/docs/admin_guide_docassemble/updates-and-maintenance.md
+++ b/docs/admin_guide_docassemble/updates-and-maintenance.md
@@ -201,7 +201,7 @@ Assembly Line packages.
 ### Updating the AssemblyLine packages
 
 The [Assembly
-Line](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/) project's
+Line](https://assemblyline.suffolklitlab.org/) project's
 framework must be updated manually, whenever there is a new feature that you 
 want. 
 
@@ -313,7 +313,7 @@ software runs within. Using a virtual machine adds to resiliency, though it also
  - How to update - See
    [Updates to the Docassemble container](maintaining-docassemble#updates-to-the-docassemble-container).
    You will use these commands: `docker stop, pull, run,` and `prune`. 
-    - If you [updated the nginx timeout to 5 minutes](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/installation/#increase-nginx-timeouts-to-5-minutes)
+    - If you [updated the nginx timeout to 5 minutes](https://assemblyline.suffolklitlab.org/docs/installation/#increase-nginx-timeouts-to-5-minutes)
       earlier, you will need to redo it.
     - This will pull the latest version of each package unless specific version of a package was pinned via PyPI.
   - When to update - If the [Docassemble Change Log](https://docassemble.org/docs/changelog.html) has an update

--- a/docs/components/ALKiln/intro.mdx
+++ b/docs/components/ALKiln/intro.mdx
@@ -94,7 +94,7 @@ For security, [ALKiln freezes the versions of its third-party libraries](securit
 - [GitHub setup interview](https://github.com/SuffolkLITLab/docassemble-ALKilnSetup) helps you install GitHub tests on your repository
 - [ALKilnInThePlayground](https://github.com/SuffolkLITLab/docassemble-ALKilnInThePlayground) lets you run tests from your docassemble server <!-- '...lets you run <AutoDIY/> tests from... ' -->
 - [The Story Table test generator](https://github.com/plocket/alkiln_story) uses an interview's JSON variables to create a file containing a Story Table test
-- [This documentation's repository](https://github.com/SuffolkLITLab/docassemble-AssemblyLine-documentation/tree/main/docs/alkiln) is on GitHub too
+- [This documentation's repository](https://github.com/SuffolkLITLab/AssemblyLine-docs/tree/main/docs/alkiln) is on GitHub too
 
 
 ## How can you contribute? {#contribute}

--- a/docs/components/FormFyxer/lit_explorer.md
+++ b/docs/components/FormFyxer/lit_explorer.md
@@ -83,7 +83,7 @@ def regex_norm_field(text: str)
 ```
 
 Apply some heuristics to a field name to see if we can get it to match AssemblyLine conventions.
-See: https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/document_variables
+See: https://assemblyline.suffolklitlab.org/docs/document_variables
 
 <a id="formfyxer.lit_explorer.reformat_field"></a>
 

--- a/docs/docassemble_intro/theming-docassemble.md
+++ b/docs/docassemble_intro/theming-docassemble.md
@@ -214,4 +214,4 @@ custom font),you may need to do a `docker stop -t 600 mycontainer` followed by a
 
 ## See also
 
-* [Customizing Assembly Line interviews](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/customization/overview)
+* [Customizing Assembly Line interviews](https://assemblyline.suffolklitlab.org/docs/customization/overview)

--- a/docs/docassemble_intro/yaml.md
+++ b/docs/docassemble_intro/yaml.md
@@ -139,4 +139,4 @@ Wait a second. Doesn't it make more sense to think of the label (First name, Las
 ## Keep reading
 
 * If you use the Assembly Line Weaver, you may want to read about the structure of a YAML file generated
-  by the [ALWeaver tool](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/generated_yaml).
+  by the [ALWeaver tool](https://assemblyline.suffolklitlab.org/docs/generated_yaml).

--- a/docs/get_started/al_project_architecture.md
+++ b/docs/get_started/al_project_architecture.md
@@ -22,7 +22,7 @@ Below is a snapshot of the Project's overall architecture as of **June 2022**. W
 | [ALDashboard](/docs/components/ALDashboard/overview) | A collection of tools to help administer a Docassemble server and debug interviews. | [SuffolkLITLab/docassemble-ALDashboard](https://github.com/SuffolkLITLab/docassemble-ALDashboard) |
 | [ALRecipes](../components/ALRecipes/alrecipes_overview.md) | Examples for Document Assembly Line interviews, plus generic Docassemble examples addressing specific needs. | [SuffolkLITLab/docassemble-ALRecipes](https://github.com/SuffolkLITLab/docassemble-ALRecipes) |
 | [InterviewStats](https://github.com/SuffolkLITLab/docassemble-InterviewStats/) | A docassemble interview that lets you view statistics from other saved interview responses. | [SuffolkLITLab/InterviewStats/docassemble-InterviewStats](https://github.com/SuffolkLITLab/docassemble-InterviewStats/) |
-| Documentation | This website. | [SuffolkLITLab/docassemble-AssemblyLine-documentation](https://github.com/SuffolkLITLab/docassemble-AssemblyLine-documentation) |
+| Documentation | This website. | [SuffolkLITLab/AssemblyLine-docs](https://github.com/SuffolkLITLab/AssemblyLine-docs) |
 | E-Filing Proxy Server |  | [SuffolkLITLab/EfileProxyServer](https://github.com/SuffolkLITLab/EfileProxyServer) |
 | E-Filing Integration |  | [SuffolkLITLab/docassemble-EFSPIntegration](https://github.com/SuffolkLITLab/docassemble-EFSPIntegration/) |
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   favicon: 'img/favicon.ico',
   organizationName: 'SuffolkLITLab', // the GitHub org name.
-  projectName: 'docassemble-AssemblyLine-documentation', // the repo name.
+  projectName: 'AssemblyLine-docs', // the repo name.
   themeConfig: {
     // Keep for the next LIT Con
     // announcementBar: {
@@ -165,7 +165,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/SuffolkLITLab/docassemble-AssemblyLine-documentation/edit/main/',
+            'https://github.com/SuffolkLITLab/AssemblyLine-docs/edit/main/',
         },
         blog: false,
         pages: {


### PR DESCRIPTION
## Summary
- update Docusaurus repo metadata (projectName and editUrl) to the renamed repo
- update internal docs links that still referenced the old docassemble-AssemblyLine-documentation slug